### PR TITLE
[issue #38] 인하우스(자체) 회원가입 + 로그인 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -12,16 +12,86 @@
 == exception-test
 테스트 전용 API 입니다.(Exception 발생시 Error 포맷에 맞는 Response 응답 여부 확인)
 
-include::{snippets}/exception-test/curl-request.adoc[]
+include::{snippets}/unknown-error-code-test/curl-request.adoc[]
 
-include::{snippets}/exception-test/http-request.adoc[]
+include::{snippets}/unknown-error-code-test/http-request.adoc[]
 
-include::{snippets}/exception-test/http-response.adoc[]
+include::{snippets}/unknown-error-code-test/http-response.adoc[]
 
-include::{snippets}/exception-test/httpie-request.adoc[]
+include::{snippets}/unknown-error-code-test/httpie-request.adoc[]
 
-include::{snippets}/exception-test/request-body.adoc[]
+include::{snippets}/unknown-error-code-test/request-body.adoc[]
 
-include::{snippets}/exception-test/response-body.adoc[]
+include::{snippets}/unknown-error-code-test/response-body.adoc[]
 
-include::{snippets}/exception-test/response-fields.adoc[]
+include::{snippets}/unknown-error-code-test/response-fields.adoc[]
+
+== common-exception-with-description
+
+include::{snippets}/common-exception-with-description/curl-request.adoc[]
+
+include::{snippets}/common-exception-with-description/http-request.adoc[]
+
+include::{snippets}/common-exception-with-description/http-response.adoc[]
+
+include::{snippets}/common-exception-with-description/httpie-request.adoc[]
+
+include::{snippets}/common-exception-with-description/request-body.adoc[]
+
+include::{snippets}/common-exception-with-description/response-body.adoc[]
+
+include::{snippets}/common-exception-with-description/response-fields.adoc[]
+
+== common-exception-with-description-and-throwable
+
+include::{snippets}/common-exception-with-description-and-throwable/curl-request.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/http-request.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/http-response.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/httpie-request.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/request-body.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/response-body.adoc[]
+
+include::{snippets}/common-exception-with-description-and-throwable/response-fields.adoc[]
+
+[[auth]]
+
+== /api/v1/auth/sign-up
+자체 구현 로그인 API
+
+include::{snippets}/register-new-user-in-house-sign-up/curl-request.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/http-request.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/http-response.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/httpie-request.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/request-body.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/request-fields.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/response-body.adoc[]
+
+include::{snippets}/register-new-user-in-house-sign-up/response-fields.adoc[]
+
+== /api/v1/auth/verify/{userInfoId}/{tokenValue}
+메일 인증 처리 API
+
+include::{snippets}/validation-new-user-test/curl-request.adoc[]
+
+include::{snippets}/validation-new-user-test/http-request.adoc[]
+
+include::{snippets}/validation-new-user-test/http-response.adoc[]
+
+include::{snippets}/validation-new-user-test/httpie-request.adoc[]
+
+include::{snippets}/validation-new-user-test/path-parameters.adoc[]
+
+include::{snippets}/validation-new-user-test/response-body.adoc[]
+
+include::{snippets}/validation-new-user-test/response-fields.adoc[]

--- a/src/main/java/product/demo/shop/CommonController.java
+++ b/src/main/java/product/demo/shop/CommonController.java
@@ -1,0 +1,21 @@
+package product.demo.shop;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// TODO : 로그인 성공 여부 테스트를 위한 API 입니다.
+@RestController
+@RequestMapping(CommonController.DEFAULT_PATH)
+public class CommonController {
+    public static final String DEFAULT_PATH = "/api/main";
+
+    @GetMapping("")
+    public String mainLoginTest(){
+        SecurityContext secContext = SecurityContextHolder.getContext();
+
+        return "Hello " + secContext.getAuthentication().getName();
+    }
+}

--- a/src/main/java/product/demo/shop/common/exception/CommonException.java
+++ b/src/main/java/product/demo/shop/common/exception/CommonException.java
@@ -13,6 +13,13 @@ public class CommonException extends RuntimeException{
     String description;
     Throwable cause;
 
+    public CommonException(HttpStatus httpStatus, String message, Throwable throwable){
+        super(message,throwable);
+        this.errorStatus = httpStatus;
+        this.errorCode = httpStatus.value();
+        this.errorMessage = message;
+    }
+
     public CommonException(ErrorCode errorCode){
         super("[ErrorCode] : " + errorCode.getErrorStatus() + "\n"
                 + "[ErrorMessage] : " + errorCode.getErrorMessage() + "\n");

--- a/src/main/java/product/demo/shop/common/exception/controller/CommonExceptionHandler.java
+++ b/src/main/java/product/demo/shop/common/exception/controller/CommonExceptionHandler.java
@@ -1,0 +1,27 @@
+package product.demo.shop.common.exception.controller;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import product.demo.shop.common.exception.CommonErrorResponse;
+import product.demo.shop.common.exception.CommonException;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+
+import javax.servlet.http.HttpServletRequest;
+
+@ControllerAdvice
+public class CommonExceptionHandler {
+
+    @ExceptionHandler(
+            {
+                    CommonException.class,
+                    PointShopAuthException.class
+            }
+    )
+    @ResponseBody
+    public ResponseEntity<CommonErrorResponse> handleTestException(CommonException e, HttpServletRequest request) {
+        return new ResponseEntity(CommonErrorResponse.createErrorResponse(e), e.getErrorStatus());
+    }
+}

--- a/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
+++ b/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
@@ -1,12 +1,15 @@
-package product.demo.shop.common.exception.controller;
+package product.demo.shop.common.exception.hadler;
 
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import product.demo.shop.common.exception.CommonErrorCode;
 import product.demo.shop.common.exception.CommonErrorResponse;
 import product.demo.shop.common.exception.CommonException;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
 import product.demo.shop.domain.auth.exception.PointShopAuthException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -21,7 +24,17 @@ public class CommonExceptionHandler {
             }
     )
     @ResponseBody
-    public ResponseEntity<CommonErrorResponse> handleTestException(CommonException e, HttpServletRequest request) {
+    public ResponseEntity<CommonErrorResponse> handleCommonException(CommonException e, HttpServletRequest request) {
         return new ResponseEntity(CommonErrorResponse.createErrorResponse(e), e.getErrorStatus());
+    }
+
+
+    @ExceptionHandler(
+            {Exception.class}
+    )
+    public ResponseEntity<CommonErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        request.getSession();
+        var boxedException = new CommonException(CommonErrorCode.UNKNOWN_ERROR,e);
+        return new ResponseEntity(CommonErrorResponse.createErrorResponse(boxedException), boxedException.getErrorStatus());
     }
 }

--- a/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
+++ b/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
@@ -1,15 +1,12 @@
 package product.demo.shop.common.exception.hadler;
 
-
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import product.demo.shop.common.exception.CommonErrorCode;
 import product.demo.shop.common.exception.CommonErrorResponse;
 import product.demo.shop.common.exception.CommonException;
-import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
 import product.demo.shop.domain.auth.exception.PointShopAuthException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -17,24 +14,20 @@ import javax.servlet.http.HttpServletRequest;
 @ControllerAdvice
 public class CommonExceptionHandler {
 
-    @ExceptionHandler(
-            {
-                    CommonException.class,
-                    PointShopAuthException.class
-            }
-    )
+    @ExceptionHandler({CommonException.class, PointShopAuthException.class})
     @ResponseBody
-    public ResponseEntity<CommonErrorResponse> handleCommonException(CommonException e, HttpServletRequest request) {
+    public ResponseEntity<CommonErrorResponse> handleCommonException(
+            CommonException e, HttpServletRequest request) {
         return new ResponseEntity(CommonErrorResponse.createErrorResponse(e), e.getErrorStatus());
     }
 
-
-    @ExceptionHandler(
-            {Exception.class}
-    )
-    public ResponseEntity<CommonErrorResponse> handleException(Exception e, HttpServletRequest request) {
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<CommonErrorResponse> handleException(
+            Exception e, HttpServletRequest request) {
         request.getSession();
-        var boxedException = new CommonException(CommonErrorCode.UNKNOWN_ERROR,e);
-        return new ResponseEntity(CommonErrorResponse.createErrorResponse(boxedException), boxedException.getErrorStatus());
+        var boxedException = new CommonException(CommonErrorCode.UNKNOWN_ERROR, e);
+        return new ResponseEntity(
+                CommonErrorResponse.createErrorResponse(boxedException),
+                boxedException.getErrorStatus());
     }
 }

--- a/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
+++ b/src/main/java/product/demo/shop/common/exception/hadler/CommonExceptionHandler.java
@@ -1,12 +1,15 @@
 package product.demo.shop.common.exception.hadler;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import product.demo.shop.common.exception.CommonErrorCode;
 import product.demo.shop.common.exception.CommonErrorResponse;
 import product.demo.shop.common.exception.CommonException;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
 import product.demo.shop.domain.auth.exception.PointShopAuthException;
 
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/product/demo/shop/configuration/AsyncConfig.java
+++ b/src/main/java/product/demo/shop/configuration/AsyncConfig.java
@@ -36,7 +36,7 @@ public class AsyncConfig extends AsyncConfigurerSupport {
         executor.setMaxPoolSize(maxPoolSize);
         executor.setQueueCapacity(queueCapacity);
 
-        executor.setTaskDecorator(new ClonedTaskDecorator());
+//        executor.setTaskDecorator(new ClonedTaskDecorator());
         executor.setThreadNamePrefix("async-task-");
         executor.setThreadGroupName("async-group");
         executor.setWaitForTasksToCompleteOnShutdown(true); // 작업의 유실을 막기 위해 큐에 남아있는 Task를 모두 처리 할 때 까지 shutdown 유보.

--- a/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
+++ b/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package product.demo.shop.configuration;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -22,7 +23,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(customUserDetailsService).passwordEncoder(passwordEncoder);
+        auth.authenticationProvider(daoAuthenticationProvider());
     }
 
     @Override
@@ -35,7 +36,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .antMatchers(AUTH_API_PATH + "/sign-up")
                 .permitAll()
-                .antMatchers("/api/v1/auth/verify/{userInfoId}/{tokenValue}")
+                .antMatchers(AUTH_API_PATH + "/verify/{userInfoId}/{tokenValue}")
                 .permitAll()
                 .antMatchers(CommonController.DEFAULT_PATH)
                 .hasAnyRole("USER")
@@ -57,5 +58,14 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .frameOptions()
                 .disable()
                 .and();
+    }
+
+    public DaoAuthenticationProvider daoAuthenticationProvider() {
+        // https://blog.devbong.com/95
+        var provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(customUserDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        provider.setHideUserNotFoundExceptions(false); // Not recommend
+        return provider;
     }
 }

--- a/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
+++ b/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
@@ -51,6 +51,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .headers()
                     .addHeaderWriter(
                         new StaticHeadersWriter("X-Content-Security-Policy", "script-src 'self'")
-                    ).frameOptions().disable();
+                    ).frameOptions().disable()
+                .and();
     }
 }

--- a/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
+++ b/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
@@ -13,7 +13,6 @@ import product.demo.shop.healthcheck.HealthCheckController;
 
 import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
 
-
 @Configuration
 @RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
@@ -23,35 +22,40 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth
-            .userDetailsService(customUserDetailsService)
-            .passwordEncoder(passwordEncoder);
+        auth.userDetailsService(customUserDetailsService).passwordEncoder(passwordEncoder);
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-        http
-                .csrf().disable()
-            .authorizeRequests()
-                .antMatchers(HealthCheckController.PING_PATH).permitAll()
-                .antMatchers(AUTH_API_PATH+"/sign-up").permitAll()
-                .antMatchers("/api/v1/auth/verify/{userInfoId}/{tokenValue}").permitAll()
-                .antMatchers(CommonController.DEFAULT_PATH).hasAnyRole("USER")
-                .anyRequest().authenticated()
-            .and()
+        http.csrf()
+                .disable()
+                .authorizeRequests()
+                .antMatchers(HealthCheckController.PING_PATH)
+                .permitAll()
+                .antMatchers(AUTH_API_PATH + "/sign-up")
+                .permitAll()
+                .antMatchers("/api/v1/auth/verify/{userInfoId}/{tokenValue}")
+                .permitAll()
+                .antMatchers(CommonController.DEFAULT_PATH)
+                .hasAnyRole("USER")
+                .anyRequest()
+                .authenticated()
+                .and()
                 .formLogin()
                 .permitAll()
-            .and()
+                .and()
                 .userDetailsService(customUserDetailsService)
                 .oauth2Login()
-            .and()
-                .logout().permitAll()
-            .and()
+                .and()
+                .logout()
+                .permitAll()
+                .and()
                 .headers()
-                    .addHeaderWriter(
-                        new StaticHeadersWriter("X-Content-Security-Policy", "script-src 'self'")
-                    ).frameOptions().disable()
+                .addHeaderWriter(
+                        new StaticHeadersWriter("X-Content-Security-Policy", "script-src 'self'"))
+                .frameOptions()
+                .disable()
                 .and();
     }
 }

--- a/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
+++ b/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
@@ -7,7 +7,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.header.writers.StaticHeadersWriter;
+import product.demo.shop.CommonController;
 import product.demo.shop.domain.user.service.CustomUserDetailsService;
+import product.demo.shop.healthcheck.HealthCheckController;
+
+import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
 
 
 @Configuration
@@ -28,13 +32,18 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         http
+                .csrf().disable()
             .authorizeRequests()
+                .antMatchers(HealthCheckController.PING_PATH).permitAll()
+                .antMatchers(AUTH_API_PATH+"/sign-up").permitAll()
+                .antMatchers("/api/v1/auth/verify/{userInfoId}/{tokenValue}").permitAll()
+                .antMatchers(CommonController.DEFAULT_PATH).hasAnyRole("USER")
                 .anyRequest().authenticated()
             .and()
-                .csrf()
+                .formLogin()
+                .permitAll()
             .and()
-                .formLogin().permitAll()
-            .and()
+                .userDetailsService(customUserDetailsService)
                 .oauth2Login()
             .and()
                 .logout().permitAll()

--- a/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
+++ b/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
@@ -16,6 +16,8 @@ import product.demo.shop.domain.auth.dto.SignupDto;
 import product.demo.shop.domain.auth.dto.requests.SignupRequest;
 import product.demo.shop.domain.auth.dto.responses.SignupResponse;
 
+import javax.validation.Valid;
+
 import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
 
 @RestController
@@ -27,7 +29,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping(path = "/sign-up")
-    public ResponseEntity<SignupResponse> signUp(@RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<SignupResponse> signUp(@RequestBody @Valid SignupRequest signupRequest) {
         return ResponseEntity.ok(
                 this.authService
                         .newUserSignUp(SignupDto.toSignupDto(signupRequest))

--- a/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
+++ b/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
@@ -22,26 +22,27 @@ import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_P
 @RequiredArgsConstructor
 @RequestMapping(AUTH_API_PATH)
 public class AuthController {
-    public static final String AUTH_API_PATH ="/api/v1/auth";
+    public static final String AUTH_API_PATH = "/api/v1/auth";
 
     private final AuthService authService;
-    private final MailValidationService mailValidationService;
 
     @PostMapping(path = "/sign-up")
     public ResponseEntity<SignupResponse> signUp(@RequestBody SignupRequest signupRequest) {
-        return ResponseEntity.ok(this.authService.newUserSignUp(SignupDto.toSignupDto(signupRequest)).toSignupResponse("SUCCESS"));
+        return ResponseEntity.ok(
+                this.authService
+                        .newUserSignUp(SignupDto.toSignupDto(signupRequest))
+                        .toSignupResponse("SUCCESS"));
     }
 
     @GetMapping(path = "/verify/{userInfoId}/{tokenValue}")
     public ResponseEntity<SignUpCompleteResponse> validationNewUser(
-            @PathVariable Long userInfoId,
-            @PathVariable String tokenValue){
+            @PathVariable Long userInfoId, @PathVariable String tokenValue) {
         return ResponseEntity.ok(this.authService.completeSignUp(userInfoId, tokenValue));
     }
 
-//    @PostMapping(path="/stand-alone-sign-in")
-//    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest signInRequest) {
-//
-//        return ResponseEntity.ok(SignInResponse.class);
-//    }
+    //    @PostMapping(path="/stand-alone-sign-in")
+    //    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest signInRequest) {
+    //
+    //        return ResponseEntity.ok(SignInResponse.class);
+    //    }
 }

--- a/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
+++ b/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
@@ -1,0 +1,46 @@
+package product.demo.shop.domain.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import product.demo.shop.domain.auth.service.AuthService;
+import product.demo.shop.domain.auth.service.MailValidationService;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.SignupDto;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+import product.demo.shop.domain.auth.dto.responses.SignupResponse;
+
+import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(AUTH_API_PATH)
+public class AuthController {
+    public static final String AUTH_API_PATH ="/api/v1/auth";
+
+    private final AuthService authService;
+    private final MailValidationService mailValidationService;
+
+    @PostMapping(path = "/sign-up")
+    public ResponseEntity<SignupResponse> signUp(@RequestBody SignupRequest signupRequest) {
+        return ResponseEntity.ok(this.authService.newUserSignUp(SignupDto.toSignupDto(signupRequest)).toSignupResponse());
+    }
+
+    @GetMapping(path = "/verify/{userInfoId}/{tokenValue}")
+    public ResponseEntity<MailValidationDto> validationNewUser(
+            @PathVariable Long userInfoId,
+            @PathVariable String tokenValue){
+        return ResponseEntity.ok(this.mailValidationService.validateMailCode(userInfoId, tokenValue));
+    }
+
+//    @PostMapping(path="/stand-alone-sign-in")
+//    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest signInRequest) {
+//
+//        return ResponseEntity.ok(SignInResponse.class);
+//    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
+++ b/src/main/java/product/demo/shop/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import product.demo.shop.domain.auth.dto.responses.SignUpCompleteResponse;
 import product.demo.shop.domain.auth.service.AuthService;
 import product.demo.shop.domain.auth.service.MailValidationService;
 import product.demo.shop.domain.auth.dto.MailValidationDto;
@@ -28,14 +29,14 @@ public class AuthController {
 
     @PostMapping(path = "/sign-up")
     public ResponseEntity<SignupResponse> signUp(@RequestBody SignupRequest signupRequest) {
-        return ResponseEntity.ok(this.authService.newUserSignUp(SignupDto.toSignupDto(signupRequest)).toSignupResponse());
+        return ResponseEntity.ok(this.authService.newUserSignUp(SignupDto.toSignupDto(signupRequest)).toSignupResponse("SUCCESS"));
     }
 
     @GetMapping(path = "/verify/{userInfoId}/{tokenValue}")
-    public ResponseEntity<MailValidationDto> validationNewUser(
+    public ResponseEntity<SignUpCompleteResponse> validationNewUser(
             @PathVariable Long userInfoId,
             @PathVariable String tokenValue){
-        return ResponseEntity.ok(this.mailValidationService.validateMailCode(userInfoId, tokenValue));
+        return ResponseEntity.ok(this.authService.completeSignUp(userInfoId, tokenValue));
     }
 
 //    @PostMapping(path="/stand-alone-sign-in")

--- a/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
@@ -43,7 +43,7 @@ public class MailValidationDto {
         this.emailVerificationEntityId = emailVerificationEntityId;
     }
 
-    public SignupResponse toSignupResponse() {
-        return SignupResponse.of(this.email, this.userInfoId, this.mailValidationUrl);
+    public SignupResponse toSignupResponse(String status) {
+        return SignupResponse.of(this.email, this.userInfoId, status);
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
@@ -18,7 +18,7 @@ public class MailValidationDto {
     private Long emailVerificationEntityId;
     private String validationStatus;
 
-    public static MailValidationDto fromMailValidRequest(
+    public static MailValidationDto makeValidationCodeFromMailValidRequest(
             MailValidationRequest mailValidationRequest) {
         var dateBytes =
                 mailValidationRequest

--- a/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
@@ -18,8 +18,8 @@ public class MailValidationDto {
     private Long emailVerificationEntityId;
     private String validationStatus;
 
-
-    public static MailValidationDto fromMailValidRequest(MailValidationRequest mailValidationRequest){
+    public static MailValidationDto fromMailValidRequest(
+            MailValidationRequest mailValidationRequest) {
         var dateBytes =
                 mailValidationRequest
                         .getAppliedAt()
@@ -29,7 +29,11 @@ public class MailValidationDto {
 
         String tokenString = UUID.nameUUIDFromBytes(dateBytes).toString();
 
-        String validUrl = "http://localhost:8077/api/v1/auth/verify/"+mailValidationRequest.getUserInfoId()+"/"+tokenString;
+        String validUrl =
+                "http://localhost:8077/api/v1/auth/verify/"
+                        + mailValidationRequest.getUserInfoId()
+                        + "/"
+                        + tokenString;
 
         return MailValidationDto.builder()
                 .email(mailValidationRequest.getEmail())
@@ -39,7 +43,7 @@ public class MailValidationDto {
                 .build();
     }
 
-    public void setEmailVerificationEntityId(Long emailVerificationEntityId){
+    public void setEmailVerificationEntityId(Long emailVerificationEntityId) {
         this.emailVerificationEntityId = emailVerificationEntityId;
     }
 

--- a/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/MailValidationDto.java
@@ -1,0 +1,49 @@
+package product.demo.shop.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.dto.responses.SignupResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class MailValidationDto {
+    private String email;
+    private String tokenString;
+    private Long userInfoId;
+    private String mailValidationUrl;
+    private Long emailVerificationEntityId;
+    private String validationStatus;
+
+
+    public static MailValidationDto fromMailValidRequest(MailValidationRequest mailValidationRequest){
+        var dateBytes =
+                mailValidationRequest
+                        .getAppliedAt()
+                        .toString()
+                        .concat(mailValidationRequest.getUserInfoId().toString())
+                        .getBytes(StandardCharsets.UTF_8);
+
+        String tokenString = UUID.nameUUIDFromBytes(dateBytes).toString();
+
+        String validUrl = "http://localhost:8077/api/v1/auth/verify/"+mailValidationRequest.getUserInfoId()+"/"+tokenString;
+
+        return MailValidationDto.builder()
+                .email(mailValidationRequest.getEmail())
+                .tokenString(tokenString)
+                .userInfoId(mailValidationRequest.getUserInfoId())
+                .mailValidationUrl(validUrl)
+                .build();
+    }
+
+    public void setEmailVerificationEntityId(Long emailVerificationEntityId){
+        this.emailVerificationEntityId = emailVerificationEntityId;
+    }
+
+    public SignupResponse toSignupResponse() {
+        return SignupResponse.of(this.email, this.userInfoId, this.mailValidationUrl);
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/SignupDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/SignupDto.java
@@ -1,0 +1,44 @@
+package product.demo.shop.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+
+@Getter
+@Builder
+public class SignupDto {
+
+    private String email;
+
+    private String userAccountId;
+
+    private String name;
+
+    private String password;
+
+    private String phoneNumber;
+
+    private String address;
+
+    private Long userInfoId;
+
+    private String emailVerificationCode;
+
+    private UserStatusType userStatus;
+
+    private String emailVerificationUrl;
+
+    public static SignupDto toSignupDto(SignupRequest request){
+        return SignupDto.builder()
+                .email(request.getEmail())
+                .userAccountId(request.getUserAccountId())
+                .name(request.getName())
+                .password(request.getPassword())
+                .phoneNumber(request.getPhoneNumber())
+                .address(request.getAddress())
+                .build();
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/SignupDto.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/SignupDto.java
@@ -31,7 +31,7 @@ public class SignupDto {
 
     private String emailVerificationUrl;
 
-    public static SignupDto toSignupDto(SignupRequest request){
+    public static SignupDto toSignupDto(SignupRequest request) {
         return SignupDto.builder()
                 .email(request.getEmail())
                 .userAccountId(request.getUserAccountId())

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/MailValidationRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/MailValidationRequest.java
@@ -1,0 +1,24 @@
+package product.demo.shop.domain.auth.dto.requests;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MailValidationRequest {
+
+    private String email;
+    private Long userInfoId;
+    private LocalDateTime appliedAt;
+
+    public static MailValidationRequest of(String email, Long userInfoId, LocalDateTime appliedAt){
+        return new MailValidationRequest(email, userInfoId, appliedAt);
+    }
+
+    public static MailValidationRequest of(String email, Long userInfoId){
+        return MailValidationRequest.of(email, userInfoId, LocalDateTime.now());
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/MailValidationRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/MailValidationRequest.java
@@ -14,11 +14,11 @@ public class MailValidationRequest {
     private Long userInfoId;
     private LocalDateTime appliedAt;
 
-    public static MailValidationRequest of(String email, Long userInfoId, LocalDateTime appliedAt){
+    public static MailValidationRequest of(String email, Long userInfoId, LocalDateTime appliedAt) {
         return new MailValidationRequest(email, userInfoId, appliedAt);
     }
 
-    public static MailValidationRequest of(String email, Long userInfoId){
+    public static MailValidationRequest of(String email, Long userInfoId) {
         return MailValidationRequest.of(email, userInfoId, LocalDateTime.now());
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
@@ -1,0 +1,34 @@
+package product.demo.shop.domain.auth.dto.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+    @Email
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String userAccountId;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private String phoneNumber;
+
+    @NotNull
+    private String address;
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
@@ -1,17 +1,17 @@
 package product.demo.shop.domain.auth.dto.requests;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
+@JsonDeserialize(builder = SignupRequest.SignupRequestBuilder.class)
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignupRequest {
     @Email
     @NotNull
@@ -31,4 +31,10 @@ public class SignupRequest {
 
     @NotNull
     private String address;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SignupRequestBuilder{
+
+    }
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
@@ -13,28 +13,19 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Builder
 public class SignupRequest {
-    @Email
-    @NotNull
-    private String email;
+    @Email @NotNull private String email;
 
-    @NotNull
-    private String userAccountId;
+    @NotNull private String userAccountId;
 
-    @NotNull
-    private String name;
+    @NotNull private String name;
 
-    @NotNull
-    private String password;
+    @NotNull private String password;
 
-    @NotNull
-    private String phoneNumber;
+    @NotNull private String phoneNumber;
 
-    @NotNull
-    private String address;
+    @NotNull private String address;
 
     @JsonPOJOBuilder(withPrefix = "")
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SignupRequestBuilder{
-
-    }
+    public static class SignupRequestBuilder {}
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/requests/SignupRequest.java
@@ -1,16 +1,17 @@
 package product.demo.shop.domain.auth.dto.requests;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
-@JsonDeserialize(builder = SignupRequest.SignupRequestBuilder.class)
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class SignupRequest {
     @Email @NotNull private String email;
@@ -24,8 +25,4 @@ public class SignupRequest {
     @NotNull private String phoneNumber;
 
     @NotNull private String address;
-
-    @JsonPOJOBuilder(withPrefix = "")
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SignupRequestBuilder {}
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
@@ -1,14 +1,19 @@
 package product.demo.shop.domain.auth.dto.responses;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import product.demo.shop.domain.user.entity.enums.UserStatusType;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignUpCompleteResponse {
     private String userAccountId;
     private UserStatusType userStatus;
+
+    public static SignUpCompleteResponse of(String userAccountId, UserStatusType userStatus) {
+        return new SignUpCompleteResponse(userAccountId, userStatus);
+    }
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
@@ -1,0 +1,12 @@
+package product.demo.shop.domain.auth.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+
+@Getter
+@AllArgsConstructor
+public class SignUpCompleteResponse {
+    private String userAccountId;
+    private UserStatusType userStatus;
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignUpCompleteResponse.java
@@ -2,10 +2,12 @@ package product.demo.shop.domain.auth.dto.responses;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import product.demo.shop.domain.user.entity.enums.UserStatusType;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class SignUpCompleteResponse {
     private String userAccountId;
     private UserStatusType userStatus;

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupResponse {
     @Email @NotNull private String email;
 

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
@@ -3,12 +3,14 @@ package product.demo.shop.domain.auth.dto.responses;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@NoArgsConstructor
 public class SignupResponse {
     @Email @NotNull private String email;
 

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
@@ -1,0 +1,26 @@
+package product.demo.shop.domain.auth.dto.responses;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class SignupResponse {
+    @Email
+    @NotNull
+    private String email;
+
+    @NotNull
+    private Long userInfoId;
+
+    @NotNull
+    private String verificationUrl;
+
+    public static SignupResponse of(String email, Long userInfoId, String verificationUrl){
+        return new SignupResponse(email, userInfoId, verificationUrl);
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
@@ -17,10 +17,9 @@ public class SignupResponse {
     @NotNull
     private Long userInfoId;
 
-    @NotNull
-    private String verificationUrl;
+    private String status;
 
-    public static SignupResponse of(String email, Long userInfoId, String verificationUrl){
-        return new SignupResponse(email, userInfoId, verificationUrl);
+    public static SignupResponse of(String email, Long userInfoId, String status){
+        return new SignupResponse(email, userInfoId, status);
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
+++ b/src/main/java/product/demo/shop/domain/auth/dto/responses/SignupResponse.java
@@ -10,16 +10,13 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class SignupResponse {
-    @Email
-    @NotNull
-    private String email;
+    @Email @NotNull private String email;
 
-    @NotNull
-    private Long userInfoId;
+    @NotNull private Long userInfoId;
 
     private String status;
 
-    public static SignupResponse of(String email, Long userInfoId, String status){
+    public static SignupResponse of(String email, Long userInfoId, String status) {
         return new SignupResponse(email, userInfoId, status);
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
+++ b/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
@@ -12,8 +12,7 @@ public enum PointShopAuthErrorCode implements ErrorCode {
     MAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증코드 만료입니다. 다시 재인증 해주세요"),
     SIGNUP_COMPLETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "가입 완료 처리 중 에러가 발생하였습니다."),
     NOT_YET_EMAIL_VERIFIED(HttpStatus.BAD_REQUEST, "아직 이메일 인증이 완료되지 않앗습니다."),
-    USER_NOT_EXISTS(HttpStatus.BAD_REQUEST, "입력한 유저는 존재하지 않습니다.")
-    ;
+    USER_NOT_EXISTS(HttpStatus.BAD_REQUEST, "입력한 유저는 존재하지 않습니다.");
 
     private HttpStatus errorStatus;
     private String errorMessage;

--- a/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
+++ b/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
@@ -1,0 +1,25 @@
+package product.demo.shop.domain.auth.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import product.demo.shop.common.exception.ErrorCode;
+
+@Getter
+public enum PointShopAuthErrorCode implements ErrorCode {
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알수 없는 서버 에러 입니다."),
+    EXIST_USER(HttpStatus.BAD_REQUEST, "이미 존재하는 유저 입니다."),
+    MAIL_VERIFICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 검증 코드 생성 중 오류 발생"),
+    MAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증코드 만료입니다. 다시 재인증 해주세요"),
+    SIGNUP_COMPLETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "가입 완료 처리 중 에러가 발생하였습니다."),
+    NOT_YET_EMAIL_VERIFIED(HttpStatus.BAD_REQUEST, "아직 이메일 인증이 완료되지 않앗습니다."),
+    USER_NOT_EXISTS(HttpStatus.BAD_REQUEST, "입력한 유저는 존재하지 않습니다.")
+    ;
+
+    private HttpStatus errorStatus;
+    private String errorMessage;
+
+    PointShopAuthErrorCode(HttpStatus errorStatus, String errorMessage) {
+        this.errorStatus = errorStatus;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
+++ b/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthErrorCode.java
@@ -11,8 +11,7 @@ public enum PointShopAuthErrorCode implements ErrorCode {
     MAIL_VERIFICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 검증 코드 생성 중 오류 발생"),
     MAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증코드 만료입니다. 다시 재인증 해주세요"),
     SIGNUP_COMPLETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "가입 완료 처리 중 에러가 발생하였습니다."),
-    NOT_YET_EMAIL_VERIFIED(HttpStatus.BAD_REQUEST, "아직 이메일 인증이 완료되지 않앗습니다."),
-    USER_NOT_EXISTS(HttpStatus.BAD_REQUEST, "입력한 유저는 존재하지 않습니다.");
+    NOT_YET_EMAIL_VERIFIED(HttpStatus.BAD_REQUEST, "아직 이메일 인증이 완료되지 않앗습니다.");
 
     private HttpStatus errorStatus;
     private String errorMessage;

--- a/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthException.java
+++ b/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthException.java
@@ -8,11 +8,12 @@ public class PointShopAuthException extends CommonException {
     public PointShopAuthException(ErrorCode errorCode) {
         super(errorCode);
     }
+
     public PointShopAuthException(ErrorCode errorCode, Throwable throwable) {
         super(errorCode, throwable);
     }
 
-    public PointShopAuthException(ErrorCode errorCode, String description){
+    public PointShopAuthException(ErrorCode errorCode, String description) {
         super(errorCode, description);
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthException.java
+++ b/src/main/java/product/demo/shop/domain/auth/exception/PointShopAuthException.java
@@ -1,0 +1,18 @@
+package product.demo.shop.domain.auth.exception;
+
+import product.demo.shop.common.exception.CommonException;
+import product.demo.shop.common.exception.ErrorCode;
+
+public class PointShopAuthException extends CommonException {
+
+    public PointShopAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public PointShopAuthException(ErrorCode errorCode, Throwable throwable) {
+        super(errorCode, throwable);
+    }
+
+    public PointShopAuthException(ErrorCode errorCode, String description){
+        super(errorCode, description);
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthService.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthService.java
@@ -7,5 +7,6 @@ import product.demo.shop.domain.auth.dto.SignupDto;
 public interface AuthService {
 
     MailValidationDto newUserSignUp(SignupDto signupDto);
+
     SignUpCompleteResponse completeSignUp(Long userInfoId, String tokenString);
 }

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthService.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthService.java
@@ -1,0 +1,11 @@
+package product.demo.shop.domain.auth.service;
+
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.responses.SignUpCompleteResponse;
+import product.demo.shop.domain.auth.dto.SignupDto;
+
+public interface AuthService {
+
+    MailValidationDto newUserSignUp(SignupDto signupDto);
+    SignUpCompleteResponse completeSignUp(Long userInfoId, String tokenString);
+}

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
@@ -66,7 +66,7 @@ public class AuthServiceImpl implements AuthService {
                 var findUser = this.userRepository.findById(userInfoId).orElseThrow();
                 findUser.changeUserStatusConfirmed();
                 this.userRepository.save(findUser);
-                return new SignUpCompleteResponse(
+                return SignUpCompleteResponse.of(
                         findUser.getUserAccountId(), findUser.getUserStatus());
             } else {
                 // 예외 처리가 귀찮아서 이렇게 둡니다.

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
@@ -16,8 +16,11 @@ import product.demo.shop.domain.grade.repository.UserGradeRepository;
 import product.demo.shop.domain.user.entity.UserEntity;
 import product.demo.shop.domain.user.repository.UserRepository;
 
+import javax.transaction.Transactional;
+
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthServiceImpl implements AuthService {
 
 //    private final UserDetailsService customUserDetailsService;
@@ -61,6 +64,7 @@ public class AuthServiceImpl implements AuthService {
                     && validateResult.getValidationStatus().equals("CONFIRMED")) {
                 var findUser = this.userRepository.findById(userInfoId).orElseThrow();
                 findUser.changeUserStatusConfirmed();
+                this.userRepository.save(findUser);
                 return new SignUpCompleteResponse(findUser.getUserAccountId(), findUser.getUserStatus());
             } else{
                 // 예외 처리가 귀찮아서 이렇게 둡니다.

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,76 @@
+package product.demo.shop.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.SignupDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.dto.responses.SignUpCompleteResponse;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.grade.entity.UserGradeEntity;
+import product.demo.shop.domain.grade.entity.enums.GradeName;
+import product.demo.shop.domain.grade.repository.UserGradeRepository;
+import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+//    private final UserDetailsService customUserDetailsService;
+    private final UserRepository userRepository;
+    private final UserGradeRepository userGradeRepository;
+    private final MailValidationService mailValidationService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public MailValidationDto newUserSignUp(SignupDto signupDto) {
+        var exist = this.userRepository.existsByUserAccountId(signupDto.getUserAccountId());
+
+        if (exist) {
+            throw new PointShopAuthException(PointShopAuthErrorCode.EXIST_USER);
+        }
+
+        var userGrade =
+                this.userGradeRepository
+                        .findByGradeName(GradeName.BRONZE)
+                        .orElse(UserGradeEntity
+                                .builder()
+                                .userGradeId(1L) // 없으면 걍 1로
+                                .gradeName(GradeName.BRONZE)
+                                .build());
+
+        var savedUser = this.userRepository.save(
+                UserEntity.fromUserDtoWithStandAlone(signupDto,userGrade,passwordEncoder)
+        );
+
+        return mailValidationService.makeMailValidation(
+                MailValidationRequest.of(
+                        signupDto.getEmail(), savedUser.getUserInfoId()));
+    }
+
+    @Override
+    public SignUpCompleteResponse completeSignUp(Long userInfoId, String tokenString) {
+        try{
+            var validateResult = this.mailValidationService.validateMailCode(userInfoId, tokenString);
+
+            if(StringUtils.hasText(validateResult.getValidationStatus())
+                    && validateResult.getValidationStatus().equals("CONFIRMED")) {
+                var findUser = this.userRepository.findById(userInfoId).orElseThrow();
+                findUser.changeUserStatusConfirmed();
+                return new SignUpCompleteResponse(findUser.getUserAccountId(), findUser.getUserStatus());
+            } else{
+                // 예외 처리가 귀찮아서 이렇게 둡니다.
+                // 굳이 예외로 빼지 않고 디자인 해도 됩니다.
+                throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR);
+            }
+        } catch(PointShopAuthException px){
+            throw px;
+        } catch(RuntimeException ex){
+            throw new PointShopAuthException(PointShopAuthErrorCode.SIGNUP_COMPLETE_ERROR, ex);
+        }
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/AuthServiceImpl.java
@@ -23,7 +23,7 @@ import javax.transaction.Transactional;
 @Transactional
 public class AuthServiceImpl implements AuthService {
 
-//    private final UserDetailsService customUserDetailsService;
+    //    private final UserDetailsService customUserDetailsService;
     private final UserRepository userRepository;
     private final UserGradeRepository userGradeRepository;
     private final MailValidationService mailValidationService;
@@ -40,40 +40,42 @@ public class AuthServiceImpl implements AuthService {
         var userGrade =
                 this.userGradeRepository
                         .findByGradeName(GradeName.BRONZE)
-                        .orElse(UserGradeEntity
-                                .builder()
-                                .userGradeId(1L) // 없으면 걍 1로
-                                .gradeName(GradeName.BRONZE)
-                                .build());
+                        .orElse(
+                                UserGradeEntity.builder()
+                                        .userGradeId(1L) // 없으면 걍 1로
+                                        .gradeName(GradeName.BRONZE)
+                                        .build());
 
-        var savedUser = this.userRepository.save(
-                UserEntity.fromUserDtoWithStandAlone(signupDto,userGrade,passwordEncoder)
-        );
+        var savedUser =
+                this.userRepository.save(
+                        UserEntity.fromUserDtoWithStandAlone(
+                                signupDto, userGrade, passwordEncoder));
 
         return mailValidationService.makeMailValidation(
-                MailValidationRequest.of(
-                        signupDto.getEmail(), savedUser.getUserInfoId()));
+                MailValidationRequest.of(signupDto.getEmail(), savedUser.getUserInfoId()));
     }
 
     @Override
     public SignUpCompleteResponse completeSignUp(Long userInfoId, String tokenString) {
-        try{
-            var validateResult = this.mailValidationService.validateMailCode(userInfoId, tokenString);
+        try {
+            var validateResult =
+                    this.mailValidationService.validateMailCode(userInfoId, tokenString);
 
-            if(StringUtils.hasText(validateResult.getValidationStatus())
+            if (StringUtils.hasText(validateResult.getValidationStatus())
                     && validateResult.getValidationStatus().equals("CONFIRMED")) {
                 var findUser = this.userRepository.findById(userInfoId).orElseThrow();
                 findUser.changeUserStatusConfirmed();
                 this.userRepository.save(findUser);
-                return new SignUpCompleteResponse(findUser.getUserAccountId(), findUser.getUserStatus());
-            } else{
+                return new SignUpCompleteResponse(
+                        findUser.getUserAccountId(), findUser.getUserStatus());
+            } else {
                 // 예외 처리가 귀찮아서 이렇게 둡니다.
                 // 굳이 예외로 빼지 않고 디자인 해도 됩니다.
                 throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR);
             }
-        } catch(PointShopAuthException px){
+        } catch (PointShopAuthException px) {
             throw px;
-        } catch(RuntimeException ex){
+        } catch (RuntimeException ex) {
             throw new PointShopAuthException(PointShopAuthErrorCode.SIGNUP_COMPLETE_ERROR, ex);
         }
     }

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationService.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationService.java
@@ -5,5 +5,6 @@ import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
 
 public interface MailValidationService {
     MailValidationDto makeMailValidation(MailValidationRequest validationRequest);
+
     MailValidationDto validateMailCode(Long userInfoId, String tokenString);
 }

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationService.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationService.java
@@ -1,0 +1,9 @@
+package product.demo.shop.domain.auth.service;
+
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+
+public interface MailValidationService {
+    MailValidationDto makeMailValidation(MailValidationRequest validationRequest);
+    MailValidationDto validateMailCode(Long userInfoId, String tokenString);
+}

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
@@ -1,0 +1,78 @@
+package product.demo.shop.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import product.demo.shop.common.mail.EmailParameter;
+import product.demo.shop.common.mail.MailService;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.user.entity.EmailVerificationEntity;
+import product.demo.shop.domain.user.repository.jpa.EmailVerificationRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MailValidationServiceImpl implements MailValidationService{
+
+    private final MailService mailService;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Override
+    public MailValidationDto makeMailValidation(MailValidationRequest validationRequest) {
+        try{
+            var mailDto = MailValidationDto.fromMailValidRequest(validationRequest);
+
+            var savedEmail = emailVerificationRepository.save(EmailVerificationEntity.fromMailValidationDto(mailDto, 180));
+
+            mailDto.setEmailVerificationEntityId(savedEmail.getEmailVerificationCodeId());
+
+            var emailParameter = EmailParameter.builder()
+                    .receiverEmailAddress(mailDto.getEmail())
+                    .title("로그인 검증 메일입니다.")
+                    .content("<p>아래 URL을 클릭하여 인증을 완료해주세요</p>" + mailDto.getMailValidationUrl())
+                    .build();
+
+            // TODO : mailSend는 별도 스레드에서 비동기로 동작하기 때문에 완료 여부를 확인할 수 없음.
+            // 만약 완료 여부 확인이 필요하다면 Blocking을 적용하거나,
+            // 메일 전송 이력을 관리하는 Storage가 필요함.
+            mailService.sendMail(emailParameter);
+
+            return mailDto;
+        }catch(Exception ex){
+            throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR, ex); // 귀찮아서 별도의 익셉션을 만들지 않앗습니다.
+        }
+    }
+
+    @Override
+    public MailValidationDto validateMailCode(Long userInfoId, String tokenString) {
+
+        try{
+            var searchedEmail = this.emailVerificationRepository.findByUserIdAndVerificationCode(
+                    userInfoId,
+                    tokenString
+            ).orElseThrow();
+
+            if(searchedEmail.getExpiredDate().isBefore(LocalDateTime.now())) {
+                throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED); // 만료 에러
+            }
+
+            searchedEmail.changeVerifyCodeToConfirmed("CONFIRMED");
+            var updatedEntity = this.emailVerificationRepository.save(searchedEmail);
+
+            return MailValidationDto.builder()
+                    .emailVerificationEntityId(updatedEntity.getEmailVerificationCodeId())
+                    .userInfoId(updatedEntity.getUserId())
+                    .validationStatus(updatedEntity.getVerificationCodeStatus())
+                    .build();
+
+        } catch(PointShopAuthException ex){
+            throw ex;
+        } catch(RuntimeException ex){
+            throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR, ex);
+        }
+
+    }
+}

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
@@ -17,25 +17,30 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class MailValidationServiceImpl implements MailValidationService{
+public class MailValidationServiceImpl implements MailValidationService {
 
     private final MailService mailService;
     private final EmailVerificationRepository emailVerificationRepository;
 
     @Override
     public MailValidationDto makeMailValidation(MailValidationRequest validationRequest) {
-        try{
+        try {
             var mailDto = MailValidationDto.fromMailValidRequest(validationRequest);
 
-            var savedEmail = emailVerificationRepository.save(EmailVerificationEntity.fromMailValidationDto(mailDto, 180));
+            var savedEmail =
+                    emailVerificationRepository.save(
+                            EmailVerificationEntity.fromMailValidationDto(mailDto, 180));
 
             mailDto.setEmailVerificationEntityId(savedEmail.getEmailVerificationCodeId());
 
-            var emailParameter = EmailParameter.builder()
-                    .receiverEmailAddress(mailDto.getEmail())
-                    .title("로그인 검증 메일입니다.")
-                    .content("<p>아래 URL을 클릭하여 인증을 완료해주세요</p>" + mailDto.getMailValidationUrl())
-                    .build();
+            var emailParameter =
+                    EmailParameter.builder()
+                            .receiverEmailAddress(mailDto.getEmail())
+                            .title("로그인 검증 메일입니다.")
+                            .content(
+                                    "<p>아래 URL을 클릭하여 인증을 완료해주세요</p>"
+                                            + mailDto.getMailValidationUrl())
+                            .build();
 
             // TODO : mailSend는 별도 스레드에서 비동기로 동작하기 때문에 완료 여부를 확인할 수 없음.
             // 만약 완료 여부 확인이 필요하다면 Blocking을 적용하거나,
@@ -43,22 +48,24 @@ public class MailValidationServiceImpl implements MailValidationService{
             mailService.sendMail(emailParameter);
 
             return mailDto;
-        }catch(Exception ex){
-            throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR, ex); // 귀찮아서 별도의 익셉션을 만들지 않앗습니다.
+        } catch (Exception ex) {
+            throw new PointShopAuthException(
+                    PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR, ex); // 귀찮아서 별도의 익셉션을 만들지 않앗습니다.
         }
     }
 
     @Override
     public MailValidationDto validateMailCode(Long userInfoId, String tokenString) {
 
-        try{
-            var searchedEmail = this.emailVerificationRepository.findByUserIdAndVerificationCode(
-                    userInfoId,
-                    tokenString
-            ).orElseThrow();
+        try {
+            var searchedEmail =
+                    this.emailVerificationRepository
+                            .findByUserIdAndVerificationCode(userInfoId, tokenString)
+                            .orElseThrow();
 
-            if(searchedEmail.getExpiredDate().isBefore(LocalDateTime.now())) {
-                throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED); // 만료 에러
+            if (searchedEmail.getExpiredDate().isBefore(LocalDateTime.now())) {
+                throw new PointShopAuthException(
+                        PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED); // 만료 에러
             }
 
             searchedEmail.changeVerifyCodeToConfirmed("CONFIRMED");
@@ -70,11 +77,10 @@ public class MailValidationServiceImpl implements MailValidationService{
                     .validationStatus(updatedEntity.getVerificationCodeStatus())
                     .build();
 
-        } catch(PointShopAuthException ex){
+        } catch (PointShopAuthException ex) {
             throw ex;
-        } catch(RuntimeException ex){
+        } catch (RuntimeException ex) {
             throw new PointShopAuthException(PointShopAuthErrorCode.MAIL_VERIFICATION_ERROR, ex);
         }
-
     }
 }

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
@@ -11,10 +11,12 @@ import product.demo.shop.domain.auth.exception.PointShopAuthException;
 import product.demo.shop.domain.user.entity.EmailVerificationEntity;
 import product.demo.shop.domain.user.repository.jpa.EmailVerificationRepository;
 
+import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MailValidationServiceImpl implements MailValidationService{
 
     private final MailService mailService;

--- a/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
+++ b/src/main/java/product/demo/shop/domain/auth/service/MailValidationServiceImpl.java
@@ -25,7 +25,7 @@ public class MailValidationServiceImpl implements MailValidationService {
     @Override
     public MailValidationDto makeMailValidation(MailValidationRequest validationRequest) {
         try {
-            var mailDto = MailValidationDto.fromMailValidRequest(validationRequest);
+            var mailDto = MailValidationDto.makeValidationCodeFromMailValidRequest(validationRequest);
 
             var savedEmail =
                     emailVerificationRepository.save(

--- a/src/main/java/product/demo/shop/domain/grade/repository/UserGradeRepository.java
+++ b/src/main/java/product/demo/shop/domain/grade/repository/UserGradeRepository.java
@@ -2,6 +2,10 @@ package product.demo.shop.domain.grade.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import product.demo.shop.domain.grade.entity.UserGradeEntity;
+import product.demo.shop.domain.grade.entity.enums.GradeName;
+
+import java.util.Optional;
 
 public interface UserGradeRepository extends JpaRepository<UserGradeEntity, Long> {
+    Optional<UserGradeEntity> findByGradeName(GradeName gradeName);
 }

--- a/src/main/java/product/demo/shop/domain/user/entity/UserEntity.java
+++ b/src/main/java/product/demo/shop/domain/user/entity/UserEntity.java
@@ -1,12 +1,18 @@
 package product.demo.shop.domain.user.entity;
 
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import product.demo.shop.common.converter.CryptoConverter;
 import product.demo.shop.common.entity.AuditEntity;
+import product.demo.shop.domain.auth.dto.SignupDto;
+import product.demo.shop.domain.grade.entity.UserGradeEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,17 +26,15 @@ import javax.persistence.Table;
 @Builder
 public class UserEntity extends AuditEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userInfoId;
 
-    @Column
-    private long userGradeId;
+    @Column private long userGradeId;
 
-    @Column
-    private String userAccountId;
+    @Column private String userAccountId;
 
-    @Column
-    private String snsProviderType;
+    @Column private String snsProviderType;
 
     @Column
     @Convert(converter = CryptoConverter.class)
@@ -40,17 +44,43 @@ public class UserEntity extends AuditEntity {
     @Convert(converter = CryptoConverter.class)
     private String email;
 
-    @Column
-    private String phone;
+    @Column private String phone;
 
     @Column
     @Convert(converter = CryptoConverter.class)
     private String address;
 
-    @Column
-    private String password; // TODO : Password는 단방향 해싱이 되어야 한다.
+    @Column private String password; // TODO : Password는 단방향 해싱이 되어야 한다.
 
     @Column
-    private String userStatus;
+    @Enumerated(EnumType.STRING)
+    private UserStatusType userStatus;
 
+    public static UserEntity fromUserDtoWithStandAlone(
+            SignupDto signupDto, UserGradeEntity userGradeEntity, PasswordEncoder passwordEncoder) {
+        return UserEntity.builder()
+                .email(signupDto.getEmail())
+                .userAccountId(signupDto.getUserAccountId())
+                .address(signupDto.getAddress())
+                .password(passwordEncoder.encode(signupDto.getPassword()))
+                .snsProviderType("NONE")
+                .userGradeId(userGradeEntity.getUserGradeId())
+                .userStatus(UserStatusType.REGISTERED_NOT_CONFIRMED) // 메일 미인증 상태
+                .phone(signupDto.getPhoneNumber())
+                .name(signupDto.getName())
+                .build();
+    }
+
+    public void changeUserStatusConfirmed() {
+        if (this.userStatus.equals(UserStatusType.REGISTERED_NOT_CONFIRMED)) {
+            this.userStatus = UserStatusType.VERIFIED;
+        } else {
+            throw new RuntimeException(
+                    "변경 가능한 상태가 아닙니다. 현재상태 : ["
+                            + this.userStatus.name()
+                            + " / "
+                            + this.userStatus.getValue()
+                            + " ]");
+        }
+    }
 }

--- a/src/main/java/product/demo/shop/domain/user/entity/enums/UserStatusType.java
+++ b/src/main/java/product/demo/shop/domain/user/entity/enums/UserStatusType.java
@@ -1,0 +1,18 @@
+package product.demo.shop.domain.user.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserStatusType {
+
+    REGISTERED_NOT_CONFIRMED("메일 미인증 유저"),
+    VERIFY_CODE_ISSUED("메일 코드 발송 완료"),
+    VERIFIED("인증 완료 유저"),
+    VERIFICATION_FAILED("인증 실패 된 유저")
+    ;
+    private final String value;
+
+    UserStatusType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/product/demo/shop/domain/user/repository/UserRepository.java
+++ b/src/main/java/product/demo/shop/domain/user/repository/UserRepository.java
@@ -3,8 +3,15 @@ package product.demo.shop.domain.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
 import product.demo.shop.domain.user.repository.custom.CustomUserRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long>, CustomUserRepository {
+    boolean existsByUserAccountId(String userAccountId);
+//    Optional<UserEntity> findByUserStatusAndUserAccountId(UserStatusType userStatus, String userAccountId);
+    Optional<UserEntity> findByUserAccountId(String userAccountId); // userAccountId 자체가 Unique 하다고 가정.
 }

--- a/src/main/java/product/demo/shop/domain/user/repository/jpa/EmailVerificationRepository.java
+++ b/src/main/java/product/demo/shop/domain/user/repository/jpa/EmailVerificationRepository.java
@@ -3,5 +3,8 @@ package product.demo.shop.domain.user.repository.jpa;
 import org.springframework.data.jpa.repository.JpaRepository;
 import product.demo.shop.domain.user.entity.EmailVerificationEntity;
 
+import java.util.Optional;
+
 public interface EmailVerificationRepository extends JpaRepository<EmailVerificationEntity, Long> {
+    Optional<EmailVerificationEntity> findByUserIdAndVerificationCode(Long userId, String verificationCode);
 }

--- a/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
@@ -1,16 +1,45 @@
 package product.demo.shop.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+import product.demo.shop.domain.user.repository.UserRepository;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
+    private final UserRepository userRepository;
+
     @Override
-    public UserDetails loadUserByUsername(String s) throws UsernameNotFoundException {
-        //TODO 유저 로그인을 위해 UserDetails를 상속받은 클래스를 만든 후 로직에 맞게 구현 필요합니다.
-        return null;
+    public UserDetails loadUserByUsername(String userAccountId) throws UsernameNotFoundException {
+        return userRepository.findByUserAccountId(userAccountId)
+                .map(user -> {
+                    if(!user.getUserStatus().equals(UserStatusType.VERIFIED)){
+                        throw new PointShopAuthException(PointShopAuthErrorCode.NOT_YET_EMAIL_VERIFIED); // email 미인증.
+                    }
+                    return makeUserDetail(user);
+                })
+                .orElseThrow(()->new PointShopAuthException(PointShopAuthErrorCode.USER_NOT_EXISTS, "["+userAccountId+"]는 존재하지 않습니다."));
+    }
+
+    private User makeUserDetail(UserEntity userEntity) {
+        // 일단 권한은 USER로 하드코딩 박아놓는다.
+        var grantedAuthority = new SimpleGrantedAuthority("ROLE_USER");
+        return new User(
+                userEntity.getUserAccountId(),
+                userEntity.getPassword(),
+                List.of(grantedAuthority)
+        );
     }
 }

--- a/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
@@ -30,7 +30,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                     }
                     return makeUserDetail(user);
                 })
-                .orElseThrow(()->new PointShopAuthException(PointShopAuthErrorCode.USER_NOT_EXISTS, "["+userAccountId+"]는 존재하지 않습니다."));
+                .orElseThrow(()->new UsernameNotFoundException("["+userAccountId+"]는 존재하지 않습니다."));
     }
 
     private User makeUserDetail(UserEntity userEntity) {

--- a/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/product/demo/shop/domain/user/service/CustomUserDetailsService.java
@@ -23,23 +23,25 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String userAccountId) throws UsernameNotFoundException {
-        return userRepository.findByUserAccountId(userAccountId)
-                .map(user -> {
-                    if(!user.getUserStatus().equals(UserStatusType.VERIFIED)){
-                        throw new PointShopAuthException(PointShopAuthErrorCode.NOT_YET_EMAIL_VERIFIED); // email 미인증.
-                    }
-                    return makeUserDetail(user);
-                })
-                .orElseThrow(()->new UsernameNotFoundException("["+userAccountId+"]는 존재하지 않습니다."));
+        return userRepository
+                .findByUserAccountId(userAccountId)
+                .map(
+                        user -> {
+                            if (!user.getUserStatus().equals(UserStatusType.VERIFIED)) {
+                                throw new PointShopAuthException(
+                                        PointShopAuthErrorCode
+                                                .NOT_YET_EMAIL_VERIFIED); // email 미인증.
+                            }
+                            return makeUserDetail(user);
+                        })
+                .orElseThrow(
+                        () -> new UsernameNotFoundException("[" + userAccountId + "]는 존재하지 않습니다."));
     }
 
     private User makeUserDetail(UserEntity userEntity) {
         // 일단 권한은 USER로 하드코딩 박아놓는다.
         var grantedAuthority = new SimpleGrantedAuthority("ROLE_USER");
         return new User(
-                userEntity.getUserAccountId(),
-                userEntity.getPassword(),
-                List.of(grantedAuthority)
-        );
+                userEntity.getUserAccountId(), userEntity.getPassword(), List.of(grantedAuthority));
     }
 }

--- a/src/main/java/product/demo/shop/healthcheck/HealthCheckController.java
+++ b/src/main/java/product/demo/shop/healthcheck/HealthCheckController.java
@@ -1,0 +1,17 @@
+package product.demo.shop.healthcheck;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = HealthCheckController.PING_PATH)
+public class HealthCheckController {
+    public static final String PING_PATH = "/api/ping";
+
+    @GetMapping("")
+    public ResponseEntity<String>  healthCheck(){
+        return ResponseEntity.ok("Check");
+    }
+}

--- a/src/main/resources/db/migration/V1.1__insert_init_data.sql
+++ b/src/main/resources/db/migration/V1.1__insert_init_data.sql
@@ -2,7 +2,7 @@
 
 -- 비밀번호는 1234asdf!@#$ 입니다.
 INSERT INTO shopdb.tb_user_info (user_info_id, user_grade_id, user_account_id, sns_provider_type, name, email, password, phone, address, user_status, created_at, created_by, last_modified_at, last_modified_by)
-VALUES (1, 1, 'sampleUser', 'sns_provider', 'kWt413risq9mPEDZ7du4pA==', 'hFCXfu+hVGDod/khzqzgabXj1AU32KYFmDcSmV5HvVA=', '{bcrypt}$2a$10$XSRY968YOaQ0MQUYezoqQ.tes.1hn9AOhHeq3VXw9EB4.GHefq6Ee', 'encrypted', '/B5JlWGHtGtiRtW3O8TN3w==', 'CONFIRMED', '2021-10-24 15:58:20', 'point-shop', '2021-10-24 15:58:20', 'point-shop');
+VALUES (1, 1, 'sampleUser', 'sns_provider', 'kWt413risq9mPEDZ7du4pA==', 'hFCXfu+hVGDod/khzqzgabXj1AU32KYFmDcSmV5HvVA=', '{bcrypt}$2a$10$XSRY968YOaQ0MQUYezoqQ.tes.1hn9AOhHeq3VXw9EB4.GHefq6Ee', 'encrypted', '/B5JlWGHtGtiRtW3O8TN3w==', 'VERIFIED', '2021-10-24 15:58:20', 'point-shop', '2021-10-24 15:58:20', 'point-shop');
 
 -- INSERT SAMPLE GRADE
 INSERT INTO shopdb.tb_user_grade (user_grade_id, grade_name, created_at, created_by, last_modified_at, last_modified_by) VALUES (1, 'BRONZE', '2021-10-24 16:12:34', 'point-shop', '2021-10-24 16:12:34', 'point-shop');

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,6 +24,7 @@
     </rollingPolicy>
   </appender>
 
+  <logger name="org.hibernate.type" level="trace" />
 
   <root level="INFO">
     <appender-ref ref="CONSOLE" />

--- a/src/test/java/product/demo/shop/common/exception/CommonErrorCodeTest.java
+++ b/src/test/java/product/demo/shop/common/exception/CommonErrorCodeTest.java
@@ -56,7 +56,7 @@ public class CommonErrorCodeTest {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .addFilter(new CharacterEncodingFilter("UTF-8", true)) // REST Doc 한글 깨짐 방지.
                 .apply(documentationConfiguration(restDocumentationContextProvider))
-                .alwaysDo(document("{method-name}", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+//                .alwaysDo(document("{method-name}", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
                 .build();
     }
 
@@ -79,7 +79,7 @@ public class CommonErrorCodeTest {
                     assertThat("알수 없는 서버 에러 입니다.").isEqualTo(errorResponse.getErrorMessage());
                 })
                 .andDo(
-                        document("[테스트전용] CommonException 활용 테스트 코드 입니다(Errorcode)",
+                        document("unknown-error-code-test",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.responseFields(
@@ -109,7 +109,7 @@ public class CommonErrorCodeTest {
                     assertThat("알수 없는 서버 에러 입니다.").isEqualTo(errorResponse.getErrorMessage());
                 })
                 .andDo(
-                        document("[테스트전용] CommonException 활용 테스트 코드 입니다(Errorcode + Description)",
+                        document("common-exception-with-description",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.responseFields(
@@ -139,7 +139,7 @@ public class CommonErrorCodeTest {
                     assertThat("알수 없는 서버 에러 입니다.").isEqualTo(errorResponse.getErrorMessage());
                 })
                 .andDo(
-                        document("[테스트전용] CommonException 활용 테스트 코드 입니다(Errorcode + Description + throwable)",
+                        document("common-exception-with-description-and-throwable",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.responseFields(

--- a/src/test/java/product/demo/shop/domain/user/UserGradeJoinTest.java
+++ b/src/test/java/product/demo/shop/domain/user/UserGradeJoinTest.java
@@ -19,12 +19,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @Disabled
 public class UserGradeJoinTest {
 
-    @Autowired
-    UserRepository userRepository;
+    @Autowired UserRepository userRepository;
 
     @Test
     @DisplayName("Querydsl Join Test - 유저 등급과 유저 정보 조회")
-    public void userInfoDtoTest(){
+    public void userInfoDtoTest() {
         UserInfoDto userInfoDto = this.userRepository.findUserWithUserGradeInfo(1L);
 
         log.info("USER GRADE NAME : " + userInfoDto.getUserGradeName());
@@ -33,6 +32,4 @@ public class UserGradeJoinTest {
         assertThat(userInfoDto.getUserGradeName()).isEqualTo(GradeName.BRONZE);
         assertThat(userInfoDto.getEmail()).isEqualTo("sample@email.com");
     }
-
-
 }

--- a/src/test/java/product/demo/shop/domain/user/UserGradeTest.java
+++ b/src/test/java/product/demo/shop/domain/user/UserGradeTest.java
@@ -17,6 +17,7 @@ import product.demo.shop.domain.grade.entity.UserGradeEntity;
 import product.demo.shop.domain.grade.entity.enums.GradeName;
 import product.demo.shop.domain.grade.repository.UserGradeRepository;
 import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
 import product.demo.shop.domain.user.repository.UserRepository;
 
 import java.util.List;
@@ -117,7 +118,7 @@ public class UserGradeTest {
                 .phone("010-1111-1111")
                 .password("password")
                 .address("address")
-                .userStatus("CONFIRMED")
+                .userStatus(UserStatusType.VERIFIED)
                 .build();
     }
 }

--- a/src/test/java/product/demo/shop/domain/user/UserGradeTest.java
+++ b/src/test/java/product/demo/shop/domain/user/UserGradeTest.java
@@ -69,31 +69,30 @@ public class UserGradeTest {
     @DisplayName("유저 ID가 입력되었을 때, 유저 등급도 같이 조회화는 조인 쿼리 테스트")
     public void userGradeJoinTest() {
         var registeredUser =
-                userRepository
-                        .findAll()
-                        .stream()
+                userRepository.findAll().stream()
                         .findFirst()
                         .orElseThrow(
                                 () -> {
                                     throw new NoSuchElementException("주어진 조건의 User가 없습니다.");
                                 });
 
-        var searchedUserInfoDto = userRepository.findUserWithUserGradeInfo(registeredUser.getUserInfoId());
+        var searchedUserInfoDto =
+                userRepository.findUserWithUserGradeInfo(registeredUser.getUserInfoId());
 
         assertAll(
-                ()->assertNotNull(searchedUserInfoDto),
-                ()->assertEquals(registeredUser.getEmail(),searchedUserInfoDto.getEmail()),
-                ()->assertEquals(registeredUser.getUserGradeId(), searchedUserInfoDto.getUserGradeId())
-        );
+                () -> assertNotNull(searchedUserInfoDto),
+                () -> assertEquals(registeredUser.getEmail(), searchedUserInfoDto.getEmail()),
+                () ->
+                        assertEquals(
+                                registeredUser.getUserGradeId(),
+                                searchedUserInfoDto.getUserGradeId()));
     }
 
     @Test
     @DisplayName("유저 등록 시 암호화 되는 부분은 DB에 Save할 때 자동으로 암호화 되고, 읽을 때 자동으로 복호화 되어야 한다.")
-    public void saveUserEncryptDecryptTest(){
+    public void saveUserEncryptDecryptTest() {
         var registeredUser =
-                userRepository
-                        .findAll()
-                        .stream()
+                userRepository.findAll().stream()
                         .findFirst()
                         .orElseThrow(
                                 () -> {
@@ -101,15 +100,13 @@ public class UserGradeTest {
                                 });
 
         assertThat(registeredUser.getName()).isEqualTo("sample");
-        var newUser =
-                makeSampleUser("Jacob");
-        var newRegisterUser  = userRepository.saveAndFlush(newUser);
+        var newUser = makeSampleUser("Jacob");
+        var newRegisterUser = userRepository.saveAndFlush(newUser);
         assertThat(newRegisterUser.getName()).isEqualTo("Jacob");
     }
 
     private UserEntity makeSampleUser(String name) {
-        return UserEntity
-                .builder()
+        return UserEntity.builder()
                 .userGradeId(1L)
                 .userAccountId("sampleUser")
                 .snsProviderType("sns_provider")

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
@@ -1,0 +1,4 @@
+package product.demo.shop.domain.user.auth.controller;
+
+public class AuthControllerTest {
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
@@ -1,4 +1,190 @@
 package product.demo.shop.domain.user.auth.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import product.demo.shop.domain.auth.controller.AuthController;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+import product.demo.shop.domain.auth.dto.responses.SignUpCompleteResponse;
+import product.demo.shop.domain.auth.dto.responses.SignupResponse;
+import product.demo.shop.domain.auth.service.AuthServiceImpl;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
+
+@Slf4j
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class, MockitoExtension.class})
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+// @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AuthControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock private AuthServiceImpl authService;
+
+    private AuthController authController;
+
+    @Autowired
+    @Qualifier("commonObjectMapper")
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentationContextProvider) {
+
+        this.authController = new AuthController(this.authService);
+        this.mockMvc =
+                MockMvcBuilders.standaloneSetup(authController)
+                        .addFilter(new CharacterEncodingFilter("UTF-8", true)) // REST Doc 한글 깨짐 방지.
+                        .apply(documentationConfiguration(restDocumentationContextProvider))
+                        .build();
+    }
+
+    @Test
+    public void registerNewUserInHouseSignUp() throws Exception {
+        //        when(userRepository.existsByUserAccountId(any())).thenReturn(true);
+        when(authService.newUserSignUp(any()))
+                .thenReturn(
+                        MailValidationDto.makeValidationCodeFromMailValidRequest(
+                                MailValidationRequest.of("newUser@google.com", 1L)));
+
+        var testSignupReqest =
+                SignupRequest.builder()
+                        .email("newUser@google.com")
+                        .userAccountId("nickname")
+                        .name("real-name")
+                        .password("124334")
+                        .phoneNumber("010-3333-2222")
+                        .address("사랑시고백구행복동")
+                        .build();
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post(AUTH_API_PATH + "/sign-up")
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(testSignupReqest)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(
+                        mvcResult -> {
+                            log.info(
+                                    "What is its status ? : "
+                                            + mvcResult.getResponse().getStatus());
+                            var signupResponse =
+                                    this.objectMapper.readValue(
+                                            mvcResult
+                                                    .getResponse()
+                                                    .getContentAsString(StandardCharsets.UTF_8),
+                                            SignupResponse.class);
+
+                            log.info("Parsed : " + objectMapper.writeValueAsString(signupResponse));
+                            assertThat(signupResponse).isNotNull();
+                        })
+                .andDo(
+                        // Documentation
+                        document(
+                                "register-new-user-in-house-sign-up",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                PayloadDocumentation.requestFields(
+                                        PayloadDocumentation.fieldWithPath("email").description("email"),
+                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name").description("name"),
+                                        PayloadDocumentation.fieldWithPath("password").description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address").description("address")
+                                ),
+                                PayloadDocumentation.responseFields(
+                                        PayloadDocumentation.fieldWithPath("email")
+                                                .type(JsonFieldType.STRING)
+                                                .description("가입 이메일 주소"),
+                                        PayloadDocumentation.fieldWithPath("userInfoId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("UserInfoId"),
+                                        PayloadDocumentation.fieldWithPath("status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("상태값"))));
+    }
+
+    @Test
+    public void validationNewUserTest() throws Exception {
+        when(authService.completeSignUp(any(), any()))
+                .thenReturn(new SignUpCompleteResponse("jay", UserStatusType.VERIFIED));
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get(
+                                AUTH_API_PATH + "/verify/{userInfoId}/{tokenValue}",
+                                1L,
+                                "token-string"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(
+                        mvcResult -> {
+                            log.info(
+                                    "What is its status ? : "
+                                            + mvcResult.getResponse().getStatus());
+                            var signUpCompleteResponse =
+                                    this.objectMapper.readValue(
+                                            mvcResult
+                                                    .getResponse()
+                                                    .getContentAsString(StandardCharsets.UTF_8),
+                                            SignUpCompleteResponse.class);
+
+                            log.info(
+                                    "Parsed : "
+                                            + objectMapper.writeValueAsString(
+                                                    signUpCompleteResponse));
+                            assertThat(signUpCompleteResponse).isNotNull();
+                        })
+                .andDo(
+                        // Documentation
+                        document(
+                                "validation-new-user-test",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                        parameterWithName("userInfoId").description("userInfoId"),
+                                        parameterWithName("tokenValue").description("tokenValue")
+                                ),
+                                PayloadDocumentation.responseFields(
+                                        PayloadDocumentation.fieldWithPath("userAccountId")
+                                                .type(JsonFieldType.STRING)
+                                                .description("유저 가입 계졍(ID)"),
+                                        PayloadDocumentation.fieldWithPath("userStatus")
+                                                .type(JsonFieldType.STRING)
+                                                .description("유저 상태"))));
+    }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
@@ -143,7 +143,7 @@ public class AuthControllerTest {
     @Test
     public void validationNewUserTest() throws Exception {
         when(authService.completeSignUp(any(), any()))
-                .thenReturn(new SignUpCompleteResponse("jay", UserStatusType.VERIFIED));
+                .thenReturn(SignUpCompleteResponse.of("jay", UserStatusType.VERIFIED));
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders.get(

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
@@ -39,10 +39,10 @@ public class MailValidationDtoTest {
     public void toSignupResponseTest() {
         var mailValidationDto = assertDoesNotThrow(()-> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
 
-        var result = mailValidationDto.toSignupResponse();
+        var result = mailValidationDto.toSignupResponse("SUCCESS");
         assertNotNull(result.getEmail());
         assertNotNull(result.getUserInfoId());
-        assertNotNull(result.getVerificationUrl());
+        assertNotNull(result.getStatus());
     }
 
 

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
@@ -1,0 +1,49 @@
+package product.demo.shop.domain.user.auth.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ActiveProfiles("test")
+@Slf4j
+public class MailValidationDtoTest {
+
+    private final MailValidationRequest testMailValidationRequest =
+            MailValidationRequest.of("dlswp113@gmail.com", 1L);
+
+    private ObjectMapper testObjectMapper = new ObjectMapper();
+    @Test
+    @DisplayName("메일 인증코드 생성 정상 처리 확인 테스트")
+    public void fromMailValidRequestTest_Success() throws Exception{
+        var result = assertDoesNotThrow(()-> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+
+        log.info(">>>> "+testObjectMapper.writeValueAsString(result));
+        assertNotNull(result.getMailValidationUrl());
+        assertNotNull(result.getTokenString());
+
+        // 아직 Save 전이므로 아래 속성들은 NULL 이어야 한다.
+        assertNull(result.getValidationStatus());
+        assertNull(result.getEmailVerificationEntityId());
+    }
+
+    @Test
+    @DisplayName("SignupResponse 변환 테스트")
+    public void toSignupResponseTest() {
+        var mailValidationDto = assertDoesNotThrow(()-> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+
+        var result = mailValidationDto.toSignupResponse();
+        assertNotNull(result.getEmail());
+        assertNotNull(result.getUserInfoId());
+        assertNotNull(result.getVerificationUrl());
+    }
+
+
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
@@ -26,7 +26,7 @@ public class MailValidationDtoTest {
     public void fromMailValidRequestTest_Success() throws Exception {
         var result =
                 assertDoesNotThrow(
-                        () -> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+                        () -> MailValidationDto.makeValidationCodeFromMailValidRequest(testMailValidationRequest));
 
         log.info(">>>> " + testObjectMapper.writeValueAsString(result));
         assertNotNull(result.getMailValidationUrl());
@@ -42,7 +42,7 @@ public class MailValidationDtoTest {
     public void toSignupResponseTest() {
         var mailValidationDto =
                 assertDoesNotThrow(
-                        () -> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+                        () -> MailValidationDto.makeValidationCodeFromMailValidRequest(testMailValidationRequest));
 
         var result = mailValidationDto.toSignupResponse("SUCCESS");
         assertNotNull(result.getEmail());

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/MailValidationDtoTest.java
@@ -20,12 +20,15 @@ public class MailValidationDtoTest {
             MailValidationRequest.of("dlswp113@gmail.com", 1L);
 
     private ObjectMapper testObjectMapper = new ObjectMapper();
+
     @Test
     @DisplayName("메일 인증코드 생성 정상 처리 확인 테스트")
-    public void fromMailValidRequestTest_Success() throws Exception{
-        var result = assertDoesNotThrow(()-> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+    public void fromMailValidRequestTest_Success() throws Exception {
+        var result =
+                assertDoesNotThrow(
+                        () -> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
 
-        log.info(">>>> "+testObjectMapper.writeValueAsString(result));
+        log.info(">>>> " + testObjectMapper.writeValueAsString(result));
         assertNotNull(result.getMailValidationUrl());
         assertNotNull(result.getTokenString());
 
@@ -37,13 +40,13 @@ public class MailValidationDtoTest {
     @Test
     @DisplayName("SignupResponse 변환 테스트")
     public void toSignupResponseTest() {
-        var mailValidationDto = assertDoesNotThrow(()-> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
+        var mailValidationDto =
+                assertDoesNotThrow(
+                        () -> MailValidationDto.fromMailValidRequest(testMailValidationRequest));
 
         var result = mailValidationDto.toSignupResponse("SUCCESS");
         assertNotNull(result.getEmail());
         assertNotNull(result.getUserInfoId());
         assertNotNull(result.getStatus());
     }
-
-
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/SignupDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/SignupDtoTest.java
@@ -14,50 +14,59 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class SignupDtoTest {
 
     @Test
-    public void getterTest(){
-        var dto = SignupDto.builder()
-                .email("dlswp113@gmail.com")
-                .userAccountId("jay")
-                .name("hwnag")
-                .password("123454")
-                .phoneNumber("000000000")
-                .address("사랑시고백구행복동")
-                .userInfoId(1L)
-                .emailVerificationCode("1213131")
-                .userStatus(UserStatusType.REGISTERED_NOT_CONFIRMED)
-                .emailVerificationUrl("http://localhost:8080/")
-                .build();
+    public void getterTest() {
+        var dto =
+                SignupDto.builder()
+                        .email("dlswp113@gmail.com")
+                        .userAccountId("jay")
+                        .name("hwnag")
+                        .password("123454")
+                        .phoneNumber("000000000")
+                        .address("사랑시고백구행복동")
+                        .userInfoId(1L)
+                        .emailVerificationCode("1213131")
+                        .userStatus(UserStatusType.REGISTERED_NOT_CONFIRMED)
+                        .emailVerificationUrl("http://localhost:8080/")
+                        .build();
 
-            assertAll(
-                    ()->assertNotNull(dto.getEmail()),
-                    ()->assertNotNull(dto.getUserAccountId()),
-                    ()->assertNotNull(dto.getName()),
-                    ()->assertNotNull(dto.getPassword()),
-                    ()->assertNotNull(dto.getPhoneNumber()),
-                    ()->assertNotNull(dto.getAddress()),
-                    ()->assertNotNull(dto.getUserInfoId()),
-                    ()->assertNotNull(dto.getEmailVerificationCode()),
-                    ()->assertNotNull(dto.getEmailVerificationUrl()),
-                    ()->assertNotNull(dto.getUserStatus())
-            );
+        assertAll(
+                () -> assertNotNull(dto.getEmail()),
+                () -> assertNotNull(dto.getUserAccountId()),
+                () -> assertNotNull(dto.getName()),
+                () -> assertNotNull(dto.getPassword()),
+                () -> assertNotNull(dto.getPhoneNumber()),
+                () -> assertNotNull(dto.getAddress()),
+                () -> assertNotNull(dto.getUserInfoId()),
+                () -> assertNotNull(dto.getEmailVerificationCode()),
+                () -> assertNotNull(dto.getEmailVerificationUrl()),
+                () -> assertNotNull(dto.getUserStatus()));
     }
 
     @Test
-    public void toSignupDtoTest(){
-        var testRequest = SignupRequest.builder()
-                .email("dlswp113@gmail.com")
-                .name("hwang")
-                .userAccountId("jay")
-                .password("12345")
-                .phoneNumber("000-0000-0000")
-                .address("사랑시고백구행복동")
-                .build();
+    public void toSignupDtoTest() {
+        var testRequest =
+                SignupRequest.builder()
+                        .email("dlswp113@gmail.com")
+                        .name("hwang")
+                        .userAccountId("jay")
+                        .password("12345")
+                        .phoneNumber("000-0000-0000")
+                        .address("사랑시고백구행복동")
+                        .build();
 
         assertNotNull(SignupDto.toSignupDto(testRequest));
         assertAll(
-                () -> assertEquals(testRequest.getEmail(), SignupDto.toSignupDto(testRequest).getEmail()),
-                () -> assertEquals(testRequest.getAddress(), SignupDto.toSignupDto(testRequest).getAddress()),
-                () -> assertEquals(testRequest.getUserAccountId(), SignupDto.toSignupDto(testRequest).getUserAccountId())
-        );
+                () ->
+                        assertEquals(
+                                testRequest.getEmail(),
+                                SignupDto.toSignupDto(testRequest).getEmail()),
+                () ->
+                        assertEquals(
+                                testRequest.getAddress(),
+                                SignupDto.toSignupDto(testRequest).getAddress()),
+                () ->
+                        assertEquals(
+                                testRequest.getUserAccountId(),
+                                SignupDto.toSignupDto(testRequest).getUserAccountId()));
     }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/SignupDtoTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/SignupDtoTest.java
@@ -1,0 +1,63 @@
+package product.demo.shop.domain.user.auth.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.domain.auth.dto.SignupDto;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ActiveProfiles("test")
+public class SignupDtoTest {
+
+    @Test
+    public void getterTest(){
+        var dto = SignupDto.builder()
+                .email("dlswp113@gmail.com")
+                .userAccountId("jay")
+                .name("hwnag")
+                .password("123454")
+                .phoneNumber("000000000")
+                .address("사랑시고백구행복동")
+                .userInfoId(1L)
+                .emailVerificationCode("1213131")
+                .userStatus(UserStatusType.REGISTERED_NOT_CONFIRMED)
+                .emailVerificationUrl("http://localhost:8080/")
+                .build();
+
+            assertAll(
+                    ()->assertNotNull(dto.getEmail()),
+                    ()->assertNotNull(dto.getUserAccountId()),
+                    ()->assertNotNull(dto.getName()),
+                    ()->assertNotNull(dto.getPassword()),
+                    ()->assertNotNull(dto.getPhoneNumber()),
+                    ()->assertNotNull(dto.getAddress()),
+                    ()->assertNotNull(dto.getUserInfoId()),
+                    ()->assertNotNull(dto.getEmailVerificationCode()),
+                    ()->assertNotNull(dto.getEmailVerificationUrl()),
+                    ()->assertNotNull(dto.getUserStatus())
+            );
+    }
+
+    @Test
+    public void toSignupDtoTest(){
+        var testRequest = SignupRequest.builder()
+                .email("dlswp113@gmail.com")
+                .name("hwang")
+                .userAccountId("jay")
+                .password("12345")
+                .phoneNumber("000-0000-0000")
+                .address("사랑시고백구행복동")
+                .build();
+
+        assertNotNull(SignupDto.toSignupDto(testRequest));
+        assertAll(
+                () -> assertEquals(testRequest.getEmail(), SignupDto.toSignupDto(testRequest).getEmail()),
+                () -> assertEquals(testRequest.getAddress(), SignupDto.toSignupDto(testRequest).getAddress()),
+                () -> assertEquals(testRequest.getUserAccountId(), SignupDto.toSignupDto(testRequest).getUserAccountId())
+        );
+    }
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/SignupRequestTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/SignupRequestTest.java
@@ -1,0 +1,57 @@
+package product.demo.shop.domain.user.auth.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ActiveProfiles("test")
+public class SignupRequestTest {
+
+    @Test
+    public void validatorTest_success(){
+
+        var result = assertDoesNotThrow(()-> SignupRequest.builder()
+                .email("dlswp113@gmail.com")
+                .userAccountId("jay")
+                .name("hwnag")
+                .password("123454")
+                .phoneNumber("000000000")
+                .address("사랑시고백구행복동")
+                .build()
+        );
+
+        assertEquals("dlswp113@gmail.com", result.getEmail());
+    }
+//
+//    @Test
+//    public void validatorTest_failedEmail() {
+//        assertThrows(Exception.class,()-> SignupRequest.builder()
+//                .email("dlswp113")
+//                .userAccountId("jay")
+//                .name("hwnag")
+//                .password("123454")
+//                .phoneNumber("000000000")
+//                .address("사랑시고백구행복동")
+//                .build()
+//        );
+//    }
+//
+//    @Test
+//    public void validatorTest_failedNotNullProps(){
+//        assertThrows(Exception.class,()-> {
+//            var request = SignupRequest.builder()
+//                            .email("dlswp113@gmail.com")
+//                            .userAccountId("jay")
+//                            .name("hwnag")
+//                            .password(null)
+//                            .phoneNumber("000000000")
+//                            .address("사랑시고백구행복동")
+//                            .build();
+//                request.
+//                }
+//        );
+//    }
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/dto/SignupRequestTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/dto/SignupRequestTest.java
@@ -11,47 +11,49 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SignupRequestTest {
 
     @Test
-    public void validatorTest_success(){
+    public void validatorTest_success() {
 
-        var result = assertDoesNotThrow(()-> SignupRequest.builder()
-                .email("dlswp113@gmail.com")
-                .userAccountId("jay")
-                .name("hwnag")
-                .password("123454")
-                .phoneNumber("000000000")
-                .address("사랑시고백구행복동")
-                .build()
-        );
+        var result =
+                assertDoesNotThrow(
+                        () ->
+                                SignupRequest.builder()
+                                        .email("dlswp113@gmail.com")
+                                        .userAccountId("jay")
+                                        .name("hwnag")
+                                        .password("123454")
+                                        .phoneNumber("000000000")
+                                        .address("사랑시고백구행복동")
+                                        .build());
 
         assertEquals("dlswp113@gmail.com", result.getEmail());
     }
-//
-//    @Test
-//    public void validatorTest_failedEmail() {
-//        assertThrows(Exception.class,()-> SignupRequest.builder()
-//                .email("dlswp113")
-//                .userAccountId("jay")
-//                .name("hwnag")
-//                .password("123454")
-//                .phoneNumber("000000000")
-//                .address("사랑시고백구행복동")
-//                .build()
-//        );
-//    }
-//
-//    @Test
-//    public void validatorTest_failedNotNullProps(){
-//        assertThrows(Exception.class,()-> {
-//            var request = SignupRequest.builder()
-//                            .email("dlswp113@gmail.com")
-//                            .userAccountId("jay")
-//                            .name("hwnag")
-//                            .password(null)
-//                            .phoneNumber("000000000")
-//                            .address("사랑시고백구행복동")
-//                            .build();
-//                request.
-//                }
-//        );
-//    }
+    //
+    //    @Test
+    //    public void validatorTest_failedEmail() {
+    //        assertThrows(Exception.class,()-> SignupRequest.builder()
+    //                .email("dlswp113")
+    //                .userAccountId("jay")
+    //                .name("hwnag")
+    //                .password("123454")
+    //                .phoneNumber("000000000")
+    //                .address("사랑시고백구행복동")
+    //                .build()
+    //        );
+    //    }
+    //
+    //    @Test
+    //    public void validatorTest_failedNotNullProps(){
+    //        assertThrows(Exception.class,()-> {
+    //            var request = SignupRequest.builder()
+    //                            .email("dlswp113@gmail.com")
+    //                            .userAccountId("jay")
+    //                            .name("hwnag")
+    //                            .password(null)
+    //                            .phoneNumber("000000000")
+    //                            .address("사랑시고백구행복동")
+    //                            .build();
+    //                request.
+    //                }
+    //        );
+    //    }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
@@ -43,45 +43,41 @@ public class AuthServiceImplTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Autowired
-    @Mock
-    PasswordEncoder passwordEncoder;
+    @Autowired @Mock PasswordEncoder passwordEncoder;
 
-    @Autowired
-    @Mock private UserRepository userRepository;
+    @Autowired @Mock private UserRepository userRepository;
 
-    @Autowired
-    @Mock private UserGradeRepository userGradeRepository;
+    @Autowired @Mock private UserGradeRepository userGradeRepository;
 
-    @Autowired
-    @Mock private MailValidationService mailValidationService;
+    @Autowired @Mock private MailValidationService mailValidationService;
 
-    @Autowired
-    @InjectMocks private AuthServiceImpl authService;
+    @Autowired @InjectMocks private AuthServiceImpl authService;
 
     @Test
     @DisplayName("신규 유저 등록 성공 처리")
     public void newUserSignUp_success() {
-        var testInputSignupDto = SignupDto.builder()
-                .email("dlswp113@gmail.com")
-                .userAccountId("jay")
-                .address("사랑시고백구행복동")
-                .password("1234")
-                .phoneNumber("010-0000-000")
-                .name("hwang")
-                .build();
+        var testInputSignupDto =
+                SignupDto.builder()
+                        .email("dlswp113@gmail.com")
+                        .userAccountId("jay")
+                        .address("사랑시고백구행복동")
+                        .password("1234")
+                        .phoneNumber("010-0000-000")
+                        .name("hwang")
+                        .build();
 
-        var sampleUserEntity = UserEntity.fromUserDtoWithStandAlone(testInputSignupDto,UserGradeEntity.builder()
-                .userGradeId(1L)
-                .gradeName(GradeName.BRONZE)
-                .build()
-            , new BCryptPasswordEncoder()
-        );
+        var sampleUserEntity =
+                UserEntity.fromUserDtoWithStandAlone(
+                        testInputSignupDto,
+                        UserGradeEntity.builder()
+                                .userGradeId(1L)
+                                .gradeName(GradeName.BRONZE)
+                                .build(),
+                        new BCryptPasswordEncoder());
 
-        var testOutputMailValidationDto = MailValidationDto.fromMailValidRequest(MailValidationRequest.of(
-                "dlswp113@gmail.com",
-                1L
-        ));
+        var testOutputMailValidationDto =
+                MailValidationDto.fromMailValidRequest(
+                        MailValidationRequest.of("dlswp113@gmail.com", 1L));
         testOutputMailValidationDto.setEmailVerificationEntityId(2L);
 
         // given
@@ -96,14 +92,13 @@ public class AuthServiceImplTest {
 
         when(userRepository.save(any())).thenReturn(sampleUserEntity);
 
-        when(mailValidationService.makeMailValidation(any())).thenReturn(
-                testOutputMailValidationDto
-        );
+        when(mailValidationService.makeMailValidation(any()))
+                .thenReturn(testOutputMailValidationDto);
 
         when(passwordEncoder.encode(any())).thenReturn("아무거나");
 
         var testResult =
-                assertDoesNotThrow(()->this.authService.newUserSignUp(testInputSignupDto));
+                assertDoesNotThrow(() -> this.authService.newUserSignUp(testInputSignupDto));
 
         assertNotNull(testResult);
         assertNotNull(testResult.getTokenString());
@@ -112,64 +107,69 @@ public class AuthServiceImplTest {
 
     @Test
     @DisplayName("기존 등록된 유저로 신규 등록 차단")
-    public void newUserSignUp_duplicated(){
-        var testInputSignupDto = SignupDto.builder()
-                .email("dlswp113@gmail.com")
-                .userAccountId("jay")
-                .address("사랑시고백구행복동")
-                .password("1234")
-                .phoneNumber("010-0000-000")
-                .name("hwang")
-                .build();
+    public void newUserSignUp_duplicated() {
+        var testInputSignupDto =
+                SignupDto.builder()
+                        .email("dlswp113@gmail.com")
+                        .userAccountId("jay")
+                        .address("사랑시고백구행복동")
+                        .password("1234")
+                        .phoneNumber("010-0000-000")
+                        .name("hwang")
+                        .build();
 
         // given
         when(userRepository.existsByUserAccountId(any())).thenReturn(true);
 
         var resultException =
-                assertThrows(PointShopAuthException.class,()->this.authService.newUserSignUp(testInputSignupDto));
+                assertThrows(
+                        PointShopAuthException.class,
+                        () -> this.authService.newUserSignUp(testInputSignupDto));
 
         log.info(resultException.toString());
         assertEquals(HttpStatus.BAD_REQUEST, resultException.getErrorStatus());
-        assertEquals(PointShopAuthErrorCode.EXIST_USER.getErrorMessage(), resultException.getErrorMessage());
+        assertEquals(
+                PointShopAuthErrorCode.EXIST_USER.getErrorMessage(),
+                resultException.getErrorMessage());
     }
 
     @Test
     @DisplayName("이메일 인증 코드를 검증하여 자체 회원가입(inhouse signup)을 완료한다.")
-    public void completeSignUp_success() throws Exception{
-        var testInputSignupDto = SignupDto.builder()
-                .email("dlswp113@gmail.com")
-                .userAccountId("jay")
-                .address("사랑시고백구행복동")
-                .password("1234")
-                .phoneNumber("010-0000-000")
-                .name("hwang")
-                .build();
+    public void completeSignUp_success() throws Exception {
+        var testInputSignupDto =
+                SignupDto.builder()
+                        .email("dlswp113@gmail.com")
+                        .userAccountId("jay")
+                        .address("사랑시고백구행복동")
+                        .password("1234")
+                        .phoneNumber("010-0000-000")
+                        .name("hwang")
+                        .build();
 
-        var testResultMailDto = MailValidationDto.builder()
-                .emailVerificationEntityId(1L)
-                .userInfoId(1L)
-                .validationStatus("CONFIRMED")
-                .build();
+        var testResultMailDto =
+                MailValidationDto.builder()
+                        .emailVerificationEntityId(1L)
+                        .userInfoId(1L)
+                        .validationStatus("CONFIRMED")
+                        .build();
 
-        var sampleUserEntity = UserEntity.fromUserDtoWithStandAlone(testInputSignupDto,UserGradeEntity.builder()
-                .userGradeId(1L)
-                .gradeName(GradeName.BRONZE)
-                .build()
-        ,new BCryptPasswordEncoder());
+        var sampleUserEntity =
+                UserEntity.fromUserDtoWithStandAlone(
+                        testInputSignupDto,
+                        UserGradeEntity.builder()
+                                .userGradeId(1L)
+                                .gradeName(GradeName.BRONZE)
+                                .build(),
+                        new BCryptPasswordEncoder());
 
-        when(mailValidationService.validateMailCode(any(), any())).thenReturn(
-                testResultMailDto
-        );
+        when(mailValidationService.validateMailCode(any(), any())).thenReturn(testResultMailDto);
 
-        when(userRepository.findById(any())).thenReturn(Optional.of(
-                sampleUserEntity
-        ));
+        when(userRepository.findById(any())).thenReturn(Optional.of(sampleUserEntity));
 
         var signupCompleteResult =
-                assertDoesNotThrow(()->this.authService.completeSignUp(1L, "string"));
+                assertDoesNotThrow(() -> this.authService.completeSignUp(1L, "string"));
 
         log.info(objectMapper.writeValueAsString(signupCompleteResult));
-        assertEquals(UserStatusType.VERIFIED ,signupCompleteResult.getUserStatus());
+        assertEquals(UserStatusType.VERIFIED, signupCompleteResult.getUserStatus());
     }
-
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
@@ -44,15 +44,15 @@ public class AuthServiceImplTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Autowired @Mock PasswordEncoder passwordEncoder;
+    @Mock PasswordEncoder passwordEncoder;
 
-    @Autowired @Mock private UserRepository userRepository;
+    @Mock private UserRepository userRepository;
 
-    @Autowired @Mock private UserGradeRepository userGradeRepository;
+    @Mock private UserGradeRepository userGradeRepository;
 
-    @Autowired @Mock private MailValidationService mailValidationService;
+    @Mock private MailValidationService mailValidationService;
 
-    @Autowired @InjectMocks private AuthServiceImpl authService;
+    @InjectMocks private AuthServiceImpl authService;
 
     @Test
     @DisplayName("신규 유저 등록 성공 처리")

--- a/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,168 @@
+package product.demo.shop.domain.user.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.SignupDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.auth.service.AuthServiceImpl;
+import product.demo.shop.domain.auth.service.MailValidationService;
+import product.demo.shop.domain.grade.entity.UserGradeEntity;
+import product.demo.shop.domain.grade.entity.enums.GradeName;
+import product.demo.shop.domain.grade.repository.UserGradeRepository;
+import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+import product.demo.shop.domain.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class AuthServiceImplTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    @Mock private UserRepository userRepository;
+
+    @Autowired
+    @Mock private UserGradeRepository userGradeRepository;
+
+    @Autowired
+    @Mock private MailValidationService mailValidationService;
+
+    @Autowired
+    @InjectMocks private AuthServiceImpl authService;
+
+    @Test
+    @DisplayName("신규 유저 등록 성공 처리")
+    public void newUserSignUp_success() {
+        var testInputSignupDto = SignupDto.builder()
+                .email("dlswp113@gmail.com")
+                .userAccountId("jay")
+                .address("사랑시고백구행복동")
+                .password("1234")
+                .phoneNumber("010-0000-000")
+                .name("hwang")
+                .build();
+
+        var sampleUserEntity = UserEntity.fromUserDtoWithStandAlone(testInputSignupDto,UserGradeEntity.builder()
+                .userGradeId(1L)
+                .gradeName(GradeName.BRONZE)
+                .build()
+            , new BCryptPasswordEncoder()
+        );
+
+        var testOutputMailValidationDto = MailValidationDto.fromMailValidRequest(MailValidationRequest.of(
+                "dlswp113@gmail.com",
+                1L
+        ));
+        testOutputMailValidationDto.setEmailVerificationEntityId(2L);
+
+        // given
+        when(userRepository.existsByUserAccountId(any())).thenReturn(false);
+        when(userGradeRepository.findByGradeName(GradeName.BRONZE))
+                .thenReturn(
+                        Optional.of(
+                                UserGradeEntity.builder()
+                                        .userGradeId(1L)
+                                        .gradeName(GradeName.BRONZE)
+                                        .build()));
+
+        when(userRepository.save(any())).thenReturn(sampleUserEntity);
+
+        when(mailValidationService.makeMailValidation(any())).thenReturn(
+                testOutputMailValidationDto
+        );
+
+        var testResult =
+                assertDoesNotThrow(()->this.authService.newUserSignUp(testInputSignupDto));
+
+        assertNotNull(testResult);
+        assertNotNull(testResult.getTokenString());
+        assertEquals(2L, testResult.getEmailVerificationEntityId());
+    }
+
+    @Test
+    @DisplayName("기존 등록된 유저로 신규 등록 차단")
+    public void newUserSignUp_duplicated(){
+        var testInputSignupDto = SignupDto.builder()
+                .email("dlswp113@gmail.com")
+                .userAccountId("jay")
+                .address("사랑시고백구행복동")
+                .password("1234")
+                .phoneNumber("010-0000-000")
+                .name("hwang")
+                .build();
+
+        // given
+        when(userRepository.existsByUserAccountId(any())).thenReturn(true);
+
+        var resultException =
+                assertThrows(PointShopAuthException.class,()->this.authService.newUserSignUp(testInputSignupDto));
+
+        log.info(resultException.toString());
+        assertEquals(HttpStatus.BAD_REQUEST, resultException.getErrorStatus());
+        assertEquals(PointShopAuthErrorCode.EXIST_USER.getErrorMessage(), resultException.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드를 검증하여 자체 회원가입(inhouse signup)을 완료한다.")
+    public void completeSignUp_success() throws Exception{
+        var testInputSignupDto = SignupDto.builder()
+                .email("dlswp113@gmail.com")
+                .userAccountId("jay")
+                .address("사랑시고백구행복동")
+                .password("1234")
+                .phoneNumber("010-0000-000")
+                .name("hwang")
+                .build();
+
+        var testResultMailDto = MailValidationDto.builder()
+                .emailVerificationEntityId(1L)
+                .userInfoId(1L)
+                .validationStatus("CONFIRMED")
+                .build();
+
+        var sampleUserEntity = UserEntity.fromUserDtoWithStandAlone(testInputSignupDto,UserGradeEntity.builder()
+                .userGradeId(1L)
+                .gradeName(GradeName.BRONZE)
+                .build()
+        ,new BCryptPasswordEncoder());
+
+        when(mailValidationService.validateMailCode(any(), any())).thenReturn(
+                testResultMailDto
+        );
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(
+                sampleUserEntity
+        ));
+
+        var signupCompleteResult =
+                assertDoesNotThrow(()->this.authService.completeSignUp(1L, "string"));
+
+        log.info(objectMapper.writeValueAsString(signupCompleteResult));
+        assertEquals(UserStatusType.VERIFIED ,signupCompleteResult.getUserStatus());
+    }
+
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import product.demo.shop.domain.auth.dto.MailValidationDto;
 import product.demo.shop.domain.auth.dto.SignupDto;
@@ -41,6 +42,10 @@ import static org.mockito.Mockito.when;
 public class AuthServiceImplTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    @Mock
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     @Mock private UserRepository userRepository;
@@ -94,6 +99,8 @@ public class AuthServiceImplTest {
         when(mailValidationService.makeMailValidation(any())).thenReturn(
                 testOutputMailValidationDto
         );
+
+        when(passwordEncoder.encode(any())).thenReturn("아무거나");
 
         var testResult =
                 assertDoesNotThrow(()->this.authService.newUserSignUp(testInputSignupDto));

--- a/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/AuthServiceImplTest.java
@@ -76,7 +76,7 @@ public class AuthServiceImplTest {
                         new BCryptPasswordEncoder());
 
         var testOutputMailValidationDto =
-                MailValidationDto.fromMailValidRequest(
+                MailValidationDto.makeValidationCodeFromMailValidRequest(
                         MailValidationRequest.of("dlswp113@gmail.com", 1L));
         testOutputMailValidationDto.setEmailVerificationEntityId(2L);
 

--- a/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
@@ -86,7 +86,9 @@ public class CustomUserDetailServiceTest {
                         PointShopAuthException.class,
                         () -> this.userDetailsService.loadUserByUsername("jay"));
         log.info(objectMapper.writeValueAsString(exception));
-        assertEquals(PointShopAuthErrorCode.NOT_YET_EMAIL_VERIFIED.getErrorMessage(), exception.getErrorMessage());
+        assertEquals(
+                PointShopAuthErrorCode.NOT_YET_EMAIL_VERIFIED.getErrorMessage(),
+                exception.getErrorMessage());
     }
 
     @Test
@@ -100,6 +102,7 @@ public class CustomUserDetailServiceTest {
                         () -> this.userDetailsService.loadUserByUsername("jay"));
         log.info(exception.getMessage());
 
-//        assertEquals(PointShopAuthErrorCode.USER_NOT_EXISTS.getErrorMessage(), exception.getErrorMessage());
+        //        assertEquals(PointShopAuthErrorCode.USER_NOT_EXISTS.getErrorMessage(),
+        // exception.getErrorMessage());
     }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
@@ -96,10 +96,10 @@ public class CustomUserDetailServiceTest {
 
         var exception =
                 assertThrows(
-                        PointShopAuthException.class,
+                        UsernameNotFoundException.class,
                         () -> this.userDetailsService.loadUserByUsername("jay"));
-        log.info(exception.getErrorMessage());
+        log.info(exception.getMessage());
 
-        assertEquals(PointShopAuthErrorCode.USER_NOT_EXISTS.getErrorMessage(), exception.getErrorMessage());
+//        assertEquals(PointShopAuthErrorCode.USER_NOT_EXISTS.getErrorMessage(), exception.getErrorMessage());
     }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
@@ -1,0 +1,105 @@
+package product.demo.shop.domain.user.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.user.entity.UserEntity;
+import product.demo.shop.domain.user.entity.enums.UserStatusType;
+import product.demo.shop.domain.user.repository.UserRepository;
+import product.demo.shop.domain.user.service.CustomUserDetailsService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class CustomUserDetailServiceTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired @Mock private UserRepository userRepository;
+
+    @Autowired @InjectMocks private CustomUserDetailsService userDetailsService;
+
+    @Test
+    @DisplayName("등록되어 있는 유저에 대한 로그인 성공처리(ROLE_USER)")
+    public void successInHouseLogin() throws Exception {
+
+        var testUser =
+                UserEntity.builder()
+                        .userInfoId(1L)
+                        .userGradeId(1L)
+                        .userAccountId("jay")
+                        .name("hwang")
+                        .email("dlswp113@gmail.com")
+                        .phone("010-0000-0000")
+                        .address("사랑시고백구행복동")
+                        .password("1234")
+                        .userStatus(UserStatusType.VERIFIED) // Verified된 유저만 로그인 처리.
+                        .build();
+
+        when(userRepository.findByUserAccountId(any())).thenReturn(Optional.of(testUser));
+
+        var resUserDetails = this.userDetailsService.loadUserByUsername("jay");
+        log.info(objectMapper.writeValueAsString(resUserDetails));
+        assertTrue(
+                resUserDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    @DisplayName("VERIFIED 상태가 아닌유저(==이메일 미인증) 유저는 팅겨낸다.")
+    public void failInHouseLoginForNoEmailVerification() throws Exception {
+        var testUser =
+                UserEntity.builder()
+                        .userInfoId(1L)
+                        .userGradeId(1L)
+                        .userAccountId("jay")
+                        .name("hwang")
+                        .email("dlswp113@gmail.com")
+                        .phone("010-0000-0000")
+                        .address("사랑시고백구행복동")
+                        .password("1234")
+                        .userStatus(UserStatusType.REGISTERED_NOT_CONFIRMED) // 메일 미인증 유저
+                        .build();
+
+        when(userRepository.findByUserAccountId(any())).thenReturn(Optional.of(testUser));
+
+        var exception =
+                assertThrows(
+                        PointShopAuthException.class,
+                        () -> this.userDetailsService.loadUserByUsername("jay"));
+        log.info(objectMapper.writeValueAsString(exception));
+        assertEquals(PointShopAuthErrorCode.NOT_YET_EMAIL_VERIFIED.getErrorMessage(), exception.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("DB에 존재하지 않는 유저는 팅겨 낸다.")
+    public void failInHouseLoginForUserNotFoundInDB() throws Exception {
+        when(userRepository.findByUserAccountId(any())).thenReturn(Optional.empty());
+
+        var exception =
+                assertThrows(
+                        PointShopAuthException.class,
+                        () -> this.userDetailsService.loadUserByUsername("jay"));
+        log.info(exception.getErrorMessage());
+
+        assertEquals(PointShopAuthErrorCode.USER_NOT_EXISTS.getErrorMessage(), exception.getErrorMessage());
+    }
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/CustomUserDetailServiceTest.java
@@ -34,9 +34,9 @@ public class CustomUserDetailServiceTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Autowired @Mock private UserRepository userRepository;
+    @Mock private UserRepository userRepository;
 
-    @Autowired @InjectMocks private CustomUserDetailsService userDetailsService;
+    @InjectMocks private CustomUserDetailsService userDetailsService;
 
     @Test
     @DisplayName("등록되어 있는 유저에 대한 로그인 성공처리(ROLE_USER)")

--- a/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
@@ -46,7 +46,7 @@ public class MailVerificationServiceTest {
     @DisplayName("검증코드 Email 전송 로직 성공")
     public void makeMailValidation() throws Exception {
         var testRequest = MailValidationRequest.of("dlswp113@gmail.com", 1L);
-        var testValidDto = MailValidationDto.fromMailValidRequest(testRequest);
+        var testValidDto = MailValidationDto.makeValidationCodeFromMailValidRequest(testRequest);
         var testSendEmail = EmailVerificationEntity.fromMailValidationDto(testValidDto, 180);
         // given
         doNothing().when(mailService).sendMail(any());

--- a/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
@@ -36,11 +36,11 @@ import static org.mockito.Mockito.when;
 public class MailVerificationServiceTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
-    @Autowired @Mock private MailService mailService;
+    @Mock private MailService mailService;
 
-    @Autowired @Mock private EmailVerificationRepository emailVerificationRepository;
+    @Mock private EmailVerificationRepository emailVerificationRepository;
 
-    @InjectMocks @Autowired private MailValidationServiceImpl mailValidationService;
+    @InjectMocks private MailValidationServiceImpl mailValidationService;
 
     @Test
     @DisplayName("검증코드 Email 전송 로직 성공")

--- a/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
@@ -36,30 +36,25 @@ import static org.mockito.Mockito.when;
 public class MailVerificationServiceTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
-    @Autowired
-    @Mock
-    private MailService mailService;
+    @Autowired @Mock private MailService mailService;
 
-    @Autowired
-    @Mock
-    private EmailVerificationRepository emailVerificationRepository;
+    @Autowired @Mock private EmailVerificationRepository emailVerificationRepository;
 
-    @InjectMocks
-    @Autowired
-    private MailValidationServiceImpl mailValidationService;
+    @InjectMocks @Autowired private MailValidationServiceImpl mailValidationService;
 
     @Test
     @DisplayName("검증코드 Email 전송 로직 성공")
-    public void makeMailValidation() throws Exception{
+    public void makeMailValidation() throws Exception {
         var testRequest = MailValidationRequest.of("dlswp113@gmail.com", 1L);
         var testValidDto = MailValidationDto.fromMailValidRequest(testRequest);
         var testSendEmail = EmailVerificationEntity.fromMailValidationDto(testValidDto, 180);
-        //given
+        // given
         doNothing().when(mailService).sendMail(any());
         when(emailVerificationRepository.save(any())).thenReturn(testSendEmail);
 
         var result =
-                assertDoesNotThrow(()->this.mailValidationService.makeMailValidation(testRequest));
+                assertDoesNotThrow(
+                        () -> this.mailValidationService.makeMailValidation(testRequest));
 
         log.info(objectMapper.writeValueAsString(result));
         assertEquals("dlswp113@gmail.com", result.getEmail());
@@ -68,30 +63,30 @@ public class MailVerificationServiceTest {
 
     @Test
     @DisplayName("메일 인증 완료 로직 성공")
-    public void validateMailCode_success() {
-
-    }
+    public void validateMailCode_success() {}
 
     @Test
     @DisplayName("인증 코드 만료로 validateMailCode Failed")
     public void validateMailCode_expired() throws Exception {
-        var expiredEmailCode = EmailVerificationEntity.builder()
+        var expiredEmailCode =
+                EmailVerificationEntity.builder()
                         .userId(1L)
-                .verificationCode("test-Strings")
-                .expiredDate(LocalDateTime.now().minusDays(1L))
-                .emailVerificationCodeId(1L)
-                .verificationCodeStatus("CREATED")
-                .build();
+                        .verificationCode("test-Strings")
+                        .expiredDate(LocalDateTime.now().minusDays(1L))
+                        .emailVerificationCodeId(1L)
+                        .verificationCodeStatus("CREATED")
+                        .build();
 
-        when(emailVerificationRepository.findByUserIdAndVerificationCode(
-                1L,
-                "test-Strings"
-        )).thenReturn(Optional.of(expiredEmailCode));
+        when(emailVerificationRepository.findByUserIdAndVerificationCode(1L, "test-Strings"))
+                .thenReturn(Optional.of(expiredEmailCode));
 
-        var exception = assertThrows(
-                PointShopAuthException.class
-                , ()->this.mailValidationService.validateMailCode(1L, "test-Strings"));
+        var exception =
+                assertThrows(
+                        PointShopAuthException.class,
+                        () -> this.mailValidationService.validateMailCode(1L, "test-Strings"));
 
-        assertEquals(PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED.getErrorMessage(), exception.getErrorMessage());
+        assertEquals(
+                PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED.getErrorMessage(),
+                exception.getErrorMessage());
     }
 }

--- a/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
@@ -1,0 +1,97 @@
+package product.demo.shop.domain.user.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import product.demo.shop.common.mail.MailService;
+import product.demo.shop.domain.auth.dto.MailValidationDto;
+import product.demo.shop.domain.auth.dto.requests.MailValidationRequest;
+import product.demo.shop.domain.auth.exception.PointShopAuthErrorCode;
+import product.demo.shop.domain.auth.exception.PointShopAuthException;
+import product.demo.shop.domain.auth.service.MailValidationServiceImpl;
+import product.demo.shop.domain.user.entity.EmailVerificationEntity;
+import product.demo.shop.domain.user.repository.jpa.EmailVerificationRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class MailVerificationServiceTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    @Mock
+    private MailService mailService;
+
+    @Autowired
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @InjectMocks
+    @Autowired
+    private MailValidationServiceImpl mailValidationService;
+
+    @Test
+    @DisplayName("검증코드 Email 전송 로직 성공")
+    public void makeMailValidation() throws Exception{
+        var testRequest = MailValidationRequest.of("dlswp113@gmail.com", 1L);
+        var testValidDto = MailValidationDto.fromMailValidRequest(testRequest);
+        var testSendEmail = EmailVerificationEntity.fromMailValidationDto(testValidDto, 180);
+        //given
+        doNothing().when(mailService).sendMail(any());
+        when(emailVerificationRepository.save(any())).thenReturn(testSendEmail);
+
+        var result =
+                assertDoesNotThrow(()->this.mailValidationService.makeMailValidation(testRequest));
+
+        log.info(objectMapper.writeValueAsString(result));
+        assertEquals("dlswp113@gmail.com", result.getEmail());
+        assertNotNull(result.getTokenString());
+    }
+
+    @Test
+    @DisplayName("메일 인증 완료 로직 성공")
+    public void validateMailCode_success() {
+
+    }
+
+    @Test
+    @DisplayName("인증 코드 만료로 validateMailCode Failed")
+    public void validateMailCode_expired() throws Exception {
+        var expiredEmailCode = EmailVerificationEntity.builder()
+                        .userId(1L)
+                .verificationCode("test-Strings")
+                .expiredDate(LocalDateTime.now().minusDays(1L))
+                .emailVerificationCodeId(1L)
+                .verificationCodeStatus("CREATED")
+                .build();
+
+        when(emailVerificationRepository.findByUserIdAndVerificationCode(
+                1L,
+                "test-Strings"
+        )).thenReturn(Optional.of(expiredEmailCode));
+
+        var exception = assertThrows(
+                PointShopAuthException.class
+                , ()->this.mailValidationService.validateMailCode(1L, "test-Strings"));
+
+        assertEquals(PointShopAuthErrorCode.MAIL_VERIFICATION_CODE_EXPIRED.getErrorMessage(), exception.getErrorMessage());
+    }
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/service/MailVerificationServiceTest.java
@@ -63,7 +63,35 @@ public class MailVerificationServiceTest {
 
     @Test
     @DisplayName("메일 인증 완료 로직 성공")
-    public void validateMailCode_success() {}
+    public void validateMailCode_success() throws Exception {
+        when(emailVerificationRepository.findByUserIdAndVerificationCode(any(), any()))
+                .thenReturn(
+                    Optional.of(
+                            EmailVerificationEntity.builder()
+                                    .emailVerificationCodeId(1L)
+                                    .verificationCode("string")
+                                    .userId(1L)
+                                    .expiredDate(LocalDateTime.now().plusYears(90000))
+                                    .verificationCodeStatus("CREATED")
+                                    .build()
+                    )
+                );
+
+        when(emailVerificationRepository.save(any())).thenReturn(
+                EmailVerificationEntity.builder()
+                        .emailVerificationCodeId(1L)
+                        .verificationCode("string")
+                        .userId(1L)
+                        .expiredDate(LocalDateTime.now())
+                        .verificationCodeStatus("CONFIRMED")
+                        .build()
+        );
+
+        assertDoesNotThrow(()->{
+            var result = this.mailValidationService.validateMailCode(1L, "string");
+            assertEquals("CONFIRMED", result.getValidationStatus());
+        });
+    }
 
     @Test
     @DisplayName("인증 코드 만료로 validateMailCode Failed")


### PR DESCRIPTION
### [잠깐만~!] PR 체크 리스트
* [ ] 단위 테스트코드 작성 -> 작성중
* [ ] Google Coding Convention 체크 [Google Coding Convention](https://google.github.io/styleguide/javaguide.html)
* [ ] Pollishing(안쓰는 import 정리, Code Style Formatter 확인)
* [X] 로컬 서버 잘 도는지 확인


### Issue Link
[이슈 링크](https://github.com/2021-study/point-shop/issues/38)

### 주요 변경점 기술
* 자세한건 이슈란에 기록해놓겠습니다.
* 아직 happy case 위주로만 구현되어 있어 예외에 대한 방어들은 거의 없습니다.
* 자체 회원가입(REST) + 로그인(FORM LOGIN)

* 회원 가입(REST)
![image](https://user-images.githubusercontent.com/16380977/140608419-ae00fa9f-3fe8-4b26-9b63-cd96517b439b.png)

* 인증 메일 전송
![image](https://user-images.githubusercontent.com/16380977/140608447-f247aee7-0fb9-44fe-a92a-a96767c48d00.png)

* 회원 가입 후 로그인 확인
![image](https://user-images.githubusercontent.com/16380977/140608510-7fa5198b-4208-4682-b8c9-0e00a014759a.png)


