### PR TITLE
issue #38 보완 - 인증 Test case 추가, REST doc을 localhost 서버에서 조회 가능하도록 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,15 @@
                         <configuration>
                             <backend>html</backend>
                             <doctype>book</doctype>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/static/rest-docs </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/generated-docs
+                                    </directory>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -7,91 +7,155 @@
 :sectnums:
 :sectlinks:
 :sectanchors:
+:hardbreaks:
 
-[[api]]
-== exception-test
-테스트 전용 API 입니다.(Exception 발생시 Error 포맷에 맞는 Response 응답 여부 확인)
 
+== 테스트 전용 API 입니다
+[[unknown-error-code-test]]
+
+.curl-request
 include::{snippets}/unknown-error-code-test/curl-request.adoc[]
 
+.http-request
 include::{snippets}/unknown-error-code-test/http-request.adoc[]
 
-include::{snippets}/unknown-error-code-test/http-response.adoc[]
-
+.httpie-request
 include::{snippets}/unknown-error-code-test/httpie-request.adoc[]
 
+.request-body(json)
 include::{snippets}/unknown-error-code-test/request-body.adoc[]
 
+===
+
+.http-response
+include::{snippets}/unknown-error-code-test/http-response.adoc[]
+
+.response-body
 include::{snippets}/unknown-error-code-test/response-body.adoc[]
 
+.response-fields
 include::{snippets}/unknown-error-code-test/response-fields.adoc[]
 
-== common-exception-with-description
+== exception에 description추가
+[[common-exception-with-description]]
 
+.curl-request
 include::{snippets}/common-exception-with-description/curl-request.adoc[]
 
+.http-request
 include::{snippets}/common-exception-with-description/http-request.adoc[]
 
-include::{snippets}/common-exception-with-description/http-response.adoc[]
-
+.httpie-request
 include::{snippets}/common-exception-with-description/httpie-request.adoc[]
 
+.request-body
 include::{snippets}/common-exception-with-description/request-body.adoc[]
 
+.http-response
+include::{snippets}/common-exception-with-description/http-response.adoc[]
+
+.response-body
 include::{snippets}/common-exception-with-description/response-body.adoc[]
 
+.response-fields
 include::{snippets}/common-exception-with-description/response-fields.adoc[]
 
-== common-exception-with-description-and-throwable
+== exception에 description, throwable 추가
+[[common-exception-with-description-and-throwable]]
 
+.curl-request
 include::{snippets}/common-exception-with-description-and-throwable/curl-request.adoc[]
 
+.http-request
 include::{snippets}/common-exception-with-description-and-throwable/http-request.adoc[]
 
-include::{snippets}/common-exception-with-description-and-throwable/http-response.adoc[]
-
+.httpie-request
 include::{snippets}/common-exception-with-description-and-throwable/httpie-request.adoc[]
 
+.request-body
 include::{snippets}/common-exception-with-description-and-throwable/request-body.adoc[]
 
+.http-response
+include::{snippets}/common-exception-with-description-and-throwable/http-response.adoc[]
+
+.response-body
 include::{snippets}/common-exception-with-description-and-throwable/response-body.adoc[]
 
+.response-fields
 include::{snippets}/common-exception-with-description-and-throwable/response-fields.adoc[]
 
-[[auth]]
 
-== /api/v1/auth/sign-up
-자체 구현 로그인 API
+== 자체구현 회원가입 API
+[[register-new-user-in-house-sign-up]]
 
+.curl-request
 include::{snippets}/register-new-user-in-house-sign-up/curl-request.adoc[]
 
+.http-request
 include::{snippets}/register-new-user-in-house-sign-up/http-request.adoc[]
 
-include::{snippets}/register-new-user-in-house-sign-up/http-response.adoc[]
-
+.httpie-request
 include::{snippets}/register-new-user-in-house-sign-up/httpie-request.adoc[]
 
+.request-body
 include::{snippets}/register-new-user-in-house-sign-up/request-body.adoc[]
 
+.request-fields
 include::{snippets}/register-new-user-in-house-sign-up/request-fields.adoc[]
 
+.http-response
+include::{snippets}/register-new-user-in-house-sign-up/http-response.adoc[]
+
+.response-body
 include::{snippets}/register-new-user-in-house-sign-up/response-body.adoc[]
 
+.response-fields
 include::{snippets}/register-new-user-in-house-sign-up/response-fields.adoc[]
 
-== /api/v1/auth/verify/{userInfoId}/{tokenValue}
-메일 인증 처리 API
+이메일 형식에 맞지 않은 요청/응답
 
+.http-request
+include::{snippets}/email-validation-failed-in-signing-up/http-request.adoc[]
+
+.response-body
+include::{snippets}/email-validation-failed-in-signing-up/response-body.adoc[]
+
+.response-fields
+include::{snippets}/email-validation-failed-in-signing-up/response-fields.adoc[]
+
+
+NotNull에 맞지 않은 요청/응답
+
+.http-request
+include::{snippets}/notnull-validation-failed-in-signing-up/http-request.adoc[]
+
+.response-body
+include::{snippets}/notnull-validation-failed-in-signing-up/response-body.adoc[]
+
+.response-fields
+include::{snippets}/notnull-validation-failed-in-signing-up/response-fields.adoc[]
+
+
+== 메일 인증 처리 API
+[[validation-new-user-test]]
+
+.curl-request
 include::{snippets}/validation-new-user-test/curl-request.adoc[]
 
+.http-request
 include::{snippets}/validation-new-user-test/http-request.adoc[]
 
-include::{snippets}/validation-new-user-test/http-response.adoc[]
-
+.httpie-request
 include::{snippets}/validation-new-user-test/httpie-request.adoc[]
 
+.path-parameter
 include::{snippets}/validation-new-user-test/path-parameters.adoc[]
 
+.http-response
+include::{snippets}/validation-new-user-test/http-response.adoc[]
+
+.response-body
 include::{snippets}/validation-new-user-test/response-body.adoc[]
 
+.response-fields
 include::{snippets}/validation-new-user-test/response-fields.adoc[]

--- a/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
+++ b/src/main/java/product/demo/shop/configuration/WebSecurityConfig.java
@@ -32,6 +32,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.csrf()
                 .disable()
                 .authorizeRequests()
+                .antMatchers("/rest-docs/**") // Spring RestDoc 문서 조회
+                .permitAll()
                 .antMatchers(HealthCheckController.PING_PATH)
                 .permitAll()
                 .antMatchers(AUTH_API_PATH + "/sign-up")

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerRequestTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerRequestTest.java
@@ -98,13 +98,18 @@ public class AuthControllerRequestTest {
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.requestFields(
-                                        PayloadDocumentation.fieldWithPath("email").description("email"),
-                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
-                                        PayloadDocumentation.fieldWithPath("name").description("name"),
-                                        PayloadDocumentation.fieldWithPath("password").description("password"),
-                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
-                                        PayloadDocumentation.fieldWithPath("address").description("address")
-                                ),
+                                        PayloadDocumentation.fieldWithPath("email")
+                                                .description("email"),
+                                        PayloadDocumentation.fieldWithPath("userAccountId")
+                                                .description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name")
+                                                .description("name"),
+                                        PayloadDocumentation.fieldWithPath("password")
+                                                .description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber")
+                                                .description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address")
+                                                .description("address")),
                                 PayloadDocumentation.responseFields(
                                         PayloadDocumentation.fieldWithPath("errorCode")
                                                 .type(JsonFieldType.NUMBER)
@@ -148,13 +153,18 @@ public class AuthControllerRequestTest {
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.requestFields(
-                                        PayloadDocumentation.fieldWithPath("email").description("email"),
-//                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
-                                        PayloadDocumentation.fieldWithPath("name").description("name"),
-                                        PayloadDocumentation.fieldWithPath("password").description("password"),
-                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
-                                        PayloadDocumentation.fieldWithPath("address").description("address")
-                                ),
+                                        PayloadDocumentation.fieldWithPath("email")
+                                                .description("email"),
+                                        //
+                                        // PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name")
+                                                .description("name"),
+                                        PayloadDocumentation.fieldWithPath("password")
+                                                .description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber")
+                                                .description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address")
+                                                .description("address")),
                                 PayloadDocumentation.responseFields(
                                         PayloadDocumentation.fieldWithPath("errorCode")
                                                 .type(JsonFieldType.NUMBER)

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerRequestTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerRequestTest.java
@@ -1,0 +1,166 @@
+package product.demo.shop.domain.user.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import product.demo.shop.domain.auth.dto.requests.SignupRequest;
+
+import java.util.Locale;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static product.demo.shop.domain.auth.controller.AuthController.AUTH_API_PATH;
+
+/* 실 구현체 테스트 */
+@Slf4j
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthControllerRequestTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    @Qualifier("commonObjectMapper")
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setUp(
+            WebApplicationContext webApplicationContext,
+            RestDocumentationContextProvider restDocumentationContextProvider) {
+        this.mockMvc =
+                MockMvcBuilders.webAppContextSetup(
+                                webApplicationContext) // mock 객체가 아닌 WebApplicationContext를 셋업 합니다.
+                        .addFilter(new CharacterEncodingFilter("UTF-8", true)) // REST Doc 한글 깨짐 방지.
+                        .apply(documentationConfiguration(restDocumentationContextProvider))
+                        .build();
+    }
+
+    @Test
+    @DisplayName("회원 가입 시 Email 형식에 맞지 않는 요청은 spring-validation에 의해 체크 되어야 한다.")
+    public void validationEmailCheckFailTest() throws Exception {
+        var testSignupReqest =
+                SignupRequest.builder()
+                        .email("newUser-gmail.com") // email 형식에 맞지 않음.
+                        .userAccountId("nickname")
+                        .name("real-name")
+                        .password("124334")
+                        .phoneNumber("010-3333-2222")
+                        .address("사랑시고백구행복동")
+                        .build();
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post(AUTH_API_PATH + "/sign-up")
+                                .accept(MediaType.ALL_VALUE)
+                                .locale(Locale.KOREA)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(testSignupReqest)))
+                .andDo(print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value(Matchers.is(400)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.errorMessage")
+                                .value(
+                                        Matchers.is(
+                                                "[([Field] : email  [Value] : newUser-gmail.com  [Message] : 올바른 형식의 이메일 주소여야 합니다)]")))
+                .andDo(
+                        // Documentation
+                        document(
+                                "email-validation-failed-in-signing-up",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                PayloadDocumentation.requestFields(
+                                        PayloadDocumentation.fieldWithPath("email").description("email"),
+                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name").description("name"),
+                                        PayloadDocumentation.fieldWithPath("password").description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address").description("address")
+                                ),
+                                PayloadDocumentation.responseFields(
+                                        PayloadDocumentation.fieldWithPath("errorCode")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("에러 코드"),
+                                        PayloadDocumentation.fieldWithPath("errorMessage")
+                                                .type(JsonFieldType.STRING)
+                                                .description("에러 메시지"))));
+    }
+
+    @Test
+    @DisplayName("회원 가입 시 Not Null 항목에 맞지 않는 요청은 spring-validation에 의해 체크 되어야 한다.")
+    public void validationNotNullFieldFailTest() throws Exception {
+        var testSignupReqest =
+                SignupRequest.builder()
+                        .email("newUser@gmail.com")
+                        .userAccountId(null) // Not Null 형식에 맞지 않음.
+                        .name("real-name")
+                        .password("124334")
+                        .phoneNumber("010-3333-2222")
+                        .address("사랑시고백구행복동")
+                        .build();
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post(AUTH_API_PATH + "/sign-up")
+                                .accept(MediaType.ALL_VALUE)
+                                .locale(Locale.KOREA)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(testSignupReqest)))
+                .andDo(print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value(Matchers.is(400)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.errorMessage")
+                                .value(
+                                        Matchers.is(
+                                                "[([Field] : userAccountId  [Value] : null  [Message] : 널이어서는 안됩니다)]")))
+                .andDo(
+                        // Documentation
+                        document(
+                                "notnull-validation-failed-in-signing-up",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                PayloadDocumentation.requestFields(
+                                        PayloadDocumentation.fieldWithPath("email").description("email"),
+//                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name").description("name"),
+                                        PayloadDocumentation.fieldWithPath("password").description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address").description("address")
+                                ),
+                                PayloadDocumentation.responseFields(
+                                        PayloadDocumentation.fieldWithPath("errorCode")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("에러 코드"),
+                                        PayloadDocumentation.fieldWithPath("errorMessage")
+                                                .type(JsonFieldType.STRING)
+                                                .description("에러 메시지"))));
+    }
+}

--- a/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/product/demo/shop/domain/user/auth/controller/AuthControllerTest.java
@@ -121,13 +121,18 @@ public class AuthControllerTest {
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 PayloadDocumentation.requestFields(
-                                        PayloadDocumentation.fieldWithPath("email").description("email"),
-                                        PayloadDocumentation.fieldWithPath("userAccountId").description("userAccountId"),
-                                        PayloadDocumentation.fieldWithPath("name").description("name"),
-                                        PayloadDocumentation.fieldWithPath("password").description("password"),
-                                        PayloadDocumentation.fieldWithPath("phoneNumber").description("phoneNumber"),
-                                        PayloadDocumentation.fieldWithPath("address").description("address")
-                                ),
+                                        PayloadDocumentation.fieldWithPath("email")
+                                                .description("email"),
+                                        PayloadDocumentation.fieldWithPath("userAccountId")
+                                                .description("userAccountId"),
+                                        PayloadDocumentation.fieldWithPath("name")
+                                                .description("name"),
+                                        PayloadDocumentation.fieldWithPath("password")
+                                                .description("password"),
+                                        PayloadDocumentation.fieldWithPath("phoneNumber")
+                                                .description("phoneNumber"),
+                                        PayloadDocumentation.fieldWithPath("address")
+                                                .description("address")),
                                 PayloadDocumentation.responseFields(
                                         PayloadDocumentation.fieldWithPath("email")
                                                 .type(JsonFieldType.STRING)
@@ -177,8 +182,7 @@ public class AuthControllerTest {
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
                                         parameterWithName("userInfoId").description("userInfoId"),
-                                        parameterWithName("tokenValue").description("tokenValue")
-                                ),
+                                        parameterWithName("tokenValue").description("tokenValue")),
                                 PayloadDocumentation.responseFields(
                                         PayloadDocumentation.fieldWithPath("userAccountId")
                                                 .type(JsonFieldType.STRING)


### PR DESCRIPTION
### [잠깐만~!] PR 체크 리스트
![](https://t1.daumcdn.net/cfile/tistory/27710D43559DBE1607)
--

* [X] 단위 테스트코드 작성
* [X] Google Coding Convention 체크 [Google Coding Convention](https://google.github.io/styleguide/javaguide.html)
* [X] Pollishing(안쓰는 import 정리, Code Style Formatter 확인)
* [X] 로컬 서버 잘 도는지 확인


### Issue Link
[이슈 링크](https://github.com/2021-study/point-shop/issues/2)

### 주요 변경점 기술
* AuthController 예외 테스트 케이스 추가
* 로컬 호스트로 Sprin Rest Doc을 출력할 수 있도록 수정(http://localhost:8077/rest-docs/index.html)
  * ```index.adoc```을 수정하셨다면 maven clean install 이 필요합니다.
![image](https://user-images.githubusercontent.com/16380977/141654297-0c9c0a58-0fef-4bca-90cc-c68ad2b5930d.png)
